### PR TITLE
Fix CI for external PRs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,13 +26,11 @@ test_script:
   - powershell .\ci\runtests.ps1
 
 on_finish:
-  - ps: |
-      venv\Scripts\activate.ps1
-      if (Test-Path env:COVERALLS_REPO_TOKEN ) { 
-          python -m coveralls
-      } else {
-          python -m coverage
-      }
+  - cmd: |
+      venv\Scripts\activate.bat
+      IF defined COVERALLS_REPO_TOKEN (
+      python -m coveralls
+      )
       
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,13 +26,9 @@ test_script:
   - powershell .\ci\runtests.ps1
 
 on_finish:
-  - ps: |
-      venv\Scripts\activate.ps1
-      if (Test-Path env:COVERALLS_REPO_TOKEN ) { 
-      cmd /c python -m coveralls
-      } else {
-      echo "Skipping coveralls reporting for external PR"
-      }
+  - cmd: |
+      venv\Scripts\activate.bat
+      IF DEFINED COVERALLS_REPO_TOKEN (python -m coverage) ELSE (echo skipping coveralls report for external pr)
       
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,11 +26,13 @@ test_script:
   - powershell .\ci\runtests.ps1
 
 on_finish:
-  - cmd: |
-      venv\Scripts\activate.bat
-      IF defined COVERALLS_REPO_TOKEN (
-      python -m coveralls
-      )
+  - ps: |
+      venv\Scripts\activate.ps1
+      if (Test-Path env:COVERALLS_REPO_TOKEN ) { 
+      cmd /c python -m coveralls
+      } else {
+      echo "Skipping coveralls reporting for external PR"
+      }
       
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,14 @@ test_script:
   - powershell .\ci\runtests.ps1
 
 on_finish:
-  - cmd: |
-      venv\Scripts\activate.bat
-      python -m coveralls
+  - ps: |
+      venv\Scripts\activate.ps1
+      if (Test-Path env:COVERALLS_REPO_TOKEN ) { 
+          python -m coveralls
+      } else {
+          python -m coverage
+      }
+      
 
 cache:
   - ahk_install.exe -> appveyor.yml


### PR DESCRIPTION
Previously PRs would all fail due to secrets (specifically for coveralls) not being available on builds for external repos.