### PR TITLE
Add missing image search options

### DIFF
--- a/ahk/screen.py
+++ b/ahk/screen.py
@@ -6,8 +6,9 @@ from typing import Tuple, Union, Optional
 class ScreenMixin(ScriptEngine):
     def image_search(self, image_path: str,
                      upper_bound: Tuple[int, int]=(0, 0), lower_bound: Tuple[int, int]=None,
-                     coord_mode: str='Screen',
-                     scale_height: int=None, scale_width: int=None) -> Union[Tuple[int, int], None]:
+                     color_variation: int=None, coord_mode: str='Screen',
+                     scale_height: int=None, scale_width: int=None,
+                     transparent: str=None, icon: int=None) -> Union[Tuple[int, int], None]:
         """
         `AutoHotkey ImageSearch reference`_
 
@@ -21,9 +22,18 @@ class ScreenMixin(ScriptEngine):
         :param lower_bound: like ``upper_bound`` but for the lower-righthand corner of the search area e.g. (400, 800)
         defaults to screen width and height (lower right-hand corner; ``%A_ScreenWidth%``, ``%A_ScreenHeight%``).
 
+        :param color_variation: Shades of variation (up or down) for the intensity of RGB for each pixel. Equivalent of
+        ``*n`` option. Defaults to 0.
+        
         :param coord_mode: the Pixel CoordMode to use. Default is 'Screen'
         :param scale_height: Scale height in pixels. Equivalent of ``*hn`` option
         :param scale_width: Scale width in pixels. Equivalent of ``*wn`` option
+        :param transparent: Specific color in the image that will be ignored during the search. Pixels with the exact
+        color given will match any color. Can be used with color names e.g. (Black, Purple, Yellow) found
+        at https://https://www.autohotkey.com/docs/commands/Progress.htm#colors or hexadecimal values e.g.
+        (0xFFFFAA, 05FA15, 632511). Equivalent of ``*TransN`` option
+
+        :param icon: Number of the icon group to use. Equivalent of ``*Icon`` option
 
         :return: coordinates of the upper-left pixel of where the image was found on the screen; ``None`` if the image
         was not found
@@ -48,7 +58,10 @@ class ScreenMixin(ScriptEngine):
                                       coord_mode=coord_mode,
                                       scale_width=scale_width,
                                       scale_height=scale_height,
-                                      image_path=image_path)
+                                      image_path=image_path,
+                                      color_variation=color_variation,
+                                      transparent=transparent,
+                                      icon=icon)
         resp = self.run_script(script)
         try:
             return ast.literal_eval(resp)

--- a/ahk/screen.py
+++ b/ahk/screen.py
@@ -48,6 +48,17 @@ class ScreenMixin(ScriptEngine):
         elif scale_width and not scale_height:
             scale_height = -1
 
+        options = []
+        if icon:
+            options.append(f'Icon{icon}')
+        if color_variation:
+            options.append(color_variation)
+        if transparent:
+            options.append(f'Trans{transparent}')
+        if scale_width:
+            options.append(f'w{scale_width}')
+            options.append(f'h{scale_height}')
+
         x1, y1 = upper_bound
         if lower_bound:
             x2, y2 = lower_bound
@@ -56,12 +67,8 @@ class ScreenMixin(ScriptEngine):
         script = self.render_template('screen/image_search.ahk',
                                       x1=x1, x2=x2, y1=y1, y2=y2,
                                       coord_mode=coord_mode,
-                                      scale_width=scale_width,
-                                      scale_height=scale_height,
                                       image_path=image_path,
-                                      color_variation=color_variation,
-                                      transparent=transparent,
-                                      icon=icon)
+                                      options=options)
         resp = self.run_script(script)
         try:
             return ast.literal_eval(resp)

--- a/ahk/templates/screen/image_search.ahk
+++ b/ahk/templates/screen/image_search.ahk
@@ -1,7 +1,7 @@
 {% extends "base.ahk" %}
 {% block body %}
 CoordMode Pixel, {{ coord_mode }}
-ImageSearch, xpos, ypos, {{ x1 }}, {{ y1 }}, {{ x2 }}, {{ y2 }}, {% if scale_width %}*w{{ scale_width}} *h{{ scale_height }} {% endif %}{{ image_path }}
+ImageSearch, xpos, ypos, {{ x1 }}, {{ y1 }}, {{ x2 }}, {{ y2 }},{% if icon %} *Icon{{ icon }}{% endif %}{% if color_variation %} *{{ color_variation }}{% endif %}{% if transparent %} *Trans{{ transparent }}{% endif %}{% if scale_width %} *w{{ scale_width}} *h{{ scale_height }}{% endif %} {{ image_path }}
 s .= Format("({}, {})", xpos, ypos)
 FileAppend, %s%, *
 {% endblock body %}

--- a/ahk/templates/screen/image_search.ahk
+++ b/ahk/templates/screen/image_search.ahk
@@ -1,7 +1,7 @@
 {% extends "base.ahk" %}
 {% block body %}
 CoordMode Pixel, {{ coord_mode }}
-ImageSearch, xpos, ypos, {{ x1 }}, {{ y1 }}, {{ x2 }}, {{ y2 }},{% if icon %} *Icon{{ icon }}{% endif %}{% if color_variation %} *{{ color_variation }}{% endif %}{% if transparent %} *Trans{{ transparent }}{% endif %}{% if scale_width %} *w{{ scale_width}} *h{{ scale_height }}{% endif %} {{ image_path }}
+ImageSearch, xpos, ypos, {{ x1 }}, {{ y1 }}, {{ x2 }}, {{ y2 }}, {% if options %}{% for option in options %}*{{ option }} {% endfor %}{% endif %}{{ image_path }}
 s .= Format("({}, {})", xpos, ypos)
 FileAppend, %s%, *
 {% endblock body %}


### PR DESCRIPTION
Added in the rest of the image search function options. https://www.autohotkey.com/docs/commands/ImageSearch.htm

- *n (color variation): Allows the search to be more lenient with the colors in the image that it is looking for. The minimum input of 0 will cause the search to match only if all the pixel colors are exactly the same, while the maximum input of 255 will cause the search to match the pixels with any color.

- *TransN (transparent): The search ignores pixels that have the value that is passed. By editing trivial portions of the image out with a single color, only the untouched parts will be considered.

- *IconN (icon): Changes the icon group number to be used.