### PR TITLE
Fix empty string bug from send/send_raw

### DIFF
--- a/ahk/keyboard.py
+++ b/ahk/keyboard.py
@@ -121,7 +121,7 @@ class KeyboardMixin(ScriptEngine):
         :return:
         """
         script = self.render_template('keyboard/send.ahk', s=s, raw=raw, delay=delay)
-        return self.run_script(script)
+        self.run_script(script)
 
     def send_raw(self, s, delay=None):
         """


### PR DESCRIPTION
Fixes #36. Functions send and send_raw were returning empty strings. Now returns `None`.