### PR TITLE
blinking tray icon fix

### DIFF
--- a/ahk/templates/base.ahk
+++ b/ahk/templates/base.ahk
@@ -1,5 +1,6 @@
 {% block directives %}
 #NoEnv
+#NoTrayIcon
 {% for directive in directives %}
 {{ directive }}
 {% endfor %}


### PR DESCRIPTION
So if I run AHK commands several times per second, AHK icon will blink in my tray. With this simple change it stopped doing that.