### PR TITLE
run script accepts a path

### DIFF
--- a/ahk/script.py
+++ b/ahk/script.py
@@ -70,7 +70,14 @@ class ScriptEngine(object):
                 pass  # for now, this seems needed to avoid blocking and use stdin
             return proc
 
-    def run_script(self, script_text: str, decode=True, blocking=True, **runkwargs):
+    def run_script(self, script: str, decode=True, blocking=True, **runkwargs):
+        if os.path.exists(script):
+            logger.debug('Script was a valid system path, reading the file for script text')
+            with open(script) as script_file:
+                script_text = script_file.read()
+        else:
+            logger.debug('Script is not a valid system path, assuming it is script text')
+            script_text = script
         logger.debug('Running script text: %s', script_text)
         try:
             result = self._run_script(script_text, decode=decode, blocking=blocking, **runkwargs)


### PR DESCRIPTION
This adds the ability for `run_script` to accept a system path to a file to read for the script text.

For now, the file is read in Python, rather than passing the path to the AHK executable. This shouldn't cause too many issues, except where the ahk script depends on `%A_ScriptDir%`. This may change in the future, but is the easiest path to implementation right now.