### PR TITLE
Executable path safety

### DIFF
--- a/ahk/script.py
+++ b/ahk/script.py
@@ -28,11 +28,10 @@ class ScriptEngine(object):
                                           'Provide the absolute path with the `executable_path` keyword argument '
                                           'or in the AHK_PATH environment variable.')
         if not os.path.exists(executable_path):
-            raise ExecutableNotFoundError(f"File does not seems to exist: '{executable_path}'")
+            raise ExecutableNotFoundError(f"executable_path does not seems to exist: '{executable_path}' not found")
         if os.path.isdir(executable_path):
-            raise ExecutableNotFoundError(f"The path {executable_path} exists, but it seems to exist "
-                                          "but it appears to be a directory, not a file. "
-                                          "Please specify the full path to the autohotkey.exe executable file")
+            raise ExecutableNotFoundError(f"The path {executable_path} appears to be a directory, but should be a file."
+                                          " Please specify the *full path* to the autohotkey.exe executable file")
         self.executable_path = executable_path
         templates_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'templates')
         self.env = Environment(

--- a/ahk/script.py
+++ b/ahk/script.py
@@ -12,25 +12,32 @@ logger = make_logger(__name__)
 class ExecutableNotFoundError(EnvironmentError):
     pass
 
-def _resolve_executable_path(executable_path: str=''):
+
+def _resolve_executable_path(executable_path: str = ''):
     if not executable_path:
         executable_path = os.environ.get('AHK_PATH') or which('AutoHotkey.exe') or which('AutoHotkeyA32.exe')
     if not executable_path:
-        raise ExecutableNotFoundError('Could not find AutoHotkey.exe on PATH. '
-                                      'Provide the absolute path with the `executable_path` keyword argument '
-                                      'or in the AHK_PATH environment variable.')
+        raise ExecutableNotFoundError(
+            'Could not find AutoHotkey.exe on PATH. '
+            'Provide the absolute path with the `executable_path` keyword argument '
+            'or in the AHK_PATH environment variable.'
+        )
     if not os.path.exists(executable_path):
         raise ExecutableNotFoundError(f"executable_path does not seems to exist: '{executable_path}' not found")
     if os.path.isdir(executable_path):
-        raise ExecutableNotFoundError(f"The path {executable_path} appears to be a directory, but should be a file."
-                                      " Please specify the *full path* to the autohotkey.exe executable file")
+        raise ExecutableNotFoundError(
+            f"The path {executable_path} appears to be a directory, but should be a file."
+            " Please specify the *full path* to the autohotkey.exe executable file"
+        )
     if not executable_path.endswith('.exe'):
-        warnings.warn('Provided executable_path does not appear to have a .exe extension. This may be the result '
-                      'of a misconfiguration.')
+        warnings.warn(
+            'executable_path does not appear to have a .exe extension. This may be the result of a misconfiguration.'
+        )
     return executable_path
 
+
 class ScriptEngine(object):
-    def __init__(self, executable_path: str='', **kwargs):
+    def __init__(self, executable_path: str = '', **kwargs):
         """
         :param executable_path: the path to the AHK executable.
         Defaults to environ['AHK_PATH'] if not explicitly provided
@@ -38,15 +45,10 @@ class ScriptEngine(object):
         :param keep_scripts:
         :raises ExecutableNotFound: if AHK executable is not provided and cannot be found in environment variables or PATH
         """
-
         self.executable_path = _resolve_executable_path(executable_path)
 
         templates_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'templates')
-        self.env = Environment(
-            loader=FileSystemLoader(templates_path),
-            autoescape=False,
-            trim_blocks=True
-        )
+        self.env = Environment(loader=FileSystemLoader(templates_path), autoescape=False, trim_blocks=True)
 
     def render_template(self, template_name, directives=None, blocking=True, **kwargs):
         if directives is None:

--- a/ahk/script.py
+++ b/ahk/script.py
@@ -27,6 +27,12 @@ class ScriptEngine(object):
             raise ExecutableNotFoundError('Could not find AutoHotkey.exe on PATH. '
                                           'Provide the absolute path with the `executable_path` keyword argument '
                                           'or in the AHK_PATH environment variable.')
+        if not os.path.exists(executable_path):
+            raise ExecutableNotFoundError(f"File does not seems to exist: '{executable_path}'")
+        if os.path.isdir(executable_path):
+            raise ExecutableNotFoundError(f"The path {executable_path} exists, but it seems to exist "
+                                          "but it appears to be a directory, not a file. "
+                                          "Please specify the full path to the autohotkey.exe executable file")
         self.executable_path = executable_path
         templates_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'templates')
         self.env = Environment(

--- a/tests/unittests/test_executable_location.py
+++ b/tests/unittests/test_executable_location.py
@@ -29,18 +29,20 @@ def test_no_executable_raises_error():
 
 def test_executable_path_from_env():
     check_pwd()
-    with mock.patch.dict(os.environ, {'PATH': '', 'AHK_PATH': 'C:\\expected\\path\\to\\ahk.exe'}):
+    with mock.patch.dict(os.environ, {'PATH': '', 'AHK_PATH': sys.executable}):
+        # using sys.executable as a standin for any file with exe extension
         ahk = AHK()
-        assert ahk.executable_path == 'C:\\expected\\path\\to\\ahk.exe'
+        assert ahk.executable_path == sys.executable
 
 
 def test_env_var_takes_precedence_over_path():
     check_pwd()
     actual_path = AHK().executable_path
     ahk_location = os.path.abspath(os.path.dirname(actual_path))
-    with mock.patch.dict(os.environ, {'PATH': ahk_location, 'AHK_PATH':'C:\\expected\\path\\to\\ahk.exe'}):
+    with mock.patch.dict(os.environ, {'PATH': ahk_location, 'AHK_PATH': sys.executable}):
+        # using sys.executable as a standin for any file with exe extension
         ahk = AHK()
-        assert ahk.executable_path == 'C:\\expected\\path\\to\\ahk.exe'
+        assert ahk.executable_path == sys.executable
 
 
 def test_executable_from_path():
@@ -50,3 +52,12 @@ def test_executable_from_path():
     with mock.patch.dict(os.environ, {'PATH': ahk_location}, clear=True):
         ahk = AHK()
         assert ahk.executable_path == actual_path
+
+def test_executable_as_dir_raises_error():
+    some_dir = os.path.abspath(os.path.dirname(__file__))
+    with pytest.raises(ExecutableNotFoundError):
+        AHK(executable_path=some_dir)
+
+def test_file_without_exe_extension_warns():
+    with pytest.warns(UserWarning):
+        AHK(executable_path=os.path.abspath(__file__))


### PR DESCRIPTION
Provides some extra safety when misconfiguring `executable_path` argument.

Related to #69 and #32 