### PR TITLE
restore coveralls command

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ test_script:
 on_finish:
   - cmd: |
       venv\Scripts\activate.bat
-      IF DEFINED COVERALLS_REPO_TOKEN (python -m coverage) ELSE (echo skipping coveralls report for external pr)
+      IF DEFINED COVERALLS_REPO_TOKEN (python -m coveralls) ELSE (echo skipping coveralls report for external pr)
       
 
 cache:


### PR DESCRIPTION
In #49 I accidentally replaced `coveralls` with `coverage` -- causing coverage report integration with coveralls.io to stop working. This restores coverage reporting.