### PR TITLE
add (non)blocking parameter for keyboard functions

### DIFF
--- a/ahk/keyboard.py
+++ b/ahk/keyboard.py
@@ -104,14 +104,14 @@ class KeyboardMixin(ScriptEngine):
         if result == "1":
             raise TimeoutError(f'timed out waiting for {key_name}')
 
-    def type(self, s):
+    def type(self, s, blocking=True):
         """
         Sends keystrokes using send_input, also escaping the string for use in AHK.
         """
         s = escape_sequence_replace(s)
-        self.send_input(s)
+        self.send_input(s, blocking=blocking)
 
-    def send(self, s, raw=False, delay=None):
+    def send(self, s, raw=False, delay=None, blocking=True):
         """
         https://autohotkey.com/docs/commands/Send.htm
 
@@ -120,8 +120,8 @@ class KeyboardMixin(ScriptEngine):
         :param delay:
         :return:
         """
-        script = self.render_template('keyboard/send.ahk', s=s, raw=raw, delay=delay)
-        self.run_script(script)
+        script = self.render_template('keyboard/send.ahk', s=s, raw=raw, delay=delay, blocking=blocking)
+        self.run_script(script, blocking=blocking)
 
     def send_raw(self, s, delay=None):
         """
@@ -133,19 +133,20 @@ class KeyboardMixin(ScriptEngine):
         """
         return self.send(s, raw=True, delay=delay)
 
-    def send_input(self, s):
+    def send_input(self, s, blocking=True):
         """
         https://autohotkey.com/docs/commands/Send.htm
 
         :param s:
+        :param blocking:
         :return:
         """
         if len(s) > 5000:
             warnings.warn('String length greater than allowed. Characters beyond 5000 may not be sent. '
                           'See https://autohotkey.com/docs/commands/Send.htm#SendInputDetail for details.')
 
-        script = self.render_template('keyboard/send_input.ahk', s=s)
-        self.run_script(script)
+        script = self.render_template('keyboard/send_input.ahk', s=s, blocking=blocking)
+        self.run_script(script, blocking=blocking)
 
     def send_play(self, s):
         """
@@ -169,7 +170,7 @@ class KeyboardMixin(ScriptEngine):
         script = self.render_template('keyboard/send_event.ahk', s=s, delay=delay)
         self.run_script(script)
 
-    def key_press(self, key, release=True):
+    def key_press(self, key, release=True, blocking=True):
         """
         Press and (optionally) release a single key
 
@@ -178,11 +179,11 @@ class KeyboardMixin(ScriptEngine):
         :return:
         """
 
-        self.key_down(key)
+        self.key_down(key, blocking=blocking)
         if release:
-            self.key_up(key)
+            self.key_up(key, blocking=blocking)
 
-    def key_release(self, key):
+    def key_release(self, key, blocking=True):
         """
         Release a key that is currently in pressed down state
 
@@ -191,21 +192,22 @@ class KeyboardMixin(ScriptEngine):
         """
         if isinstance(key, str):
             key = Key(key_name=key)
-        return self.send_input(key.UP)
+        return self.send_input(key.UP, blocking=blocking)
 
-    def key_down(self, key):
+    def key_down(self, key, blocking=True):
         """
         Press down a key (without releasing it)
 
         :param key:
+        :param blocking:
         :return:
         """
         if isinstance(key, str):
             key = Key(key_name=key)
-        return self.send_input(key.DOWN)
+        return self.send_input(key.DOWN, blocking=blocking)
 
-    def key_up(self, key):
+    def key_up(self, key, blocking=True):
         """
         Alias for :meth:~`KeyboardMixin.key_release`
         """
-        return self.key_release(key)
+        return self.key_release(key, blocking=blocking)


### PR DESCRIPTION
Adds optional parameter to make keyboard functions non-blocking. By default, the behavior is (and always has been) to block.