### PR TITLE
Console spy

### DIFF
--- a/ahk/_console_spy.py
+++ b/ahk/_console_spy.py
@@ -12,5 +12,9 @@ def _console_spy(*args, **kwargs):
         color = ahk.pixel_get_color(*position)
         print(f'Mouse Position: {position} Pixel Color: {color} Window Title: {window.title}                ', end='\r')
 
+
 def _main():
-    _console_spy()
+    try:
+        _console_spy()
+    except KeyboardInterrupt:
+        print('Exiting.')

--- a/ahk/_console_spy.py
+++ b/ahk/_console_spy.py
@@ -1,20 +1,159 @@
+import os
+import sys
+
 from ahk import AHK
 from ahk.window import Window
 from ahk.directives import NoTrayIcon
+import ctypes
+from ctypes import wintypes
+from ctypes.wintypes import *
+import textwrap
+
+_last_title_length = 0
+
+
+def _print_fields(position, color, title):
+    global _last_title_length
+    title_message = f'Window Title: {title}'
+    needed_whitespace = _last_title_length - len(title_message)
+    whitespace = ' ' * needed_whitespace
+    _last_title_length = len(title_message)
+
+    lines = [
+        f'Mouse Position: {position}        ',
+        f'Pixel Color: {color}     ',
+        f'{title_message}{whitespace}'
+    ]
+    for index, line in enumerate(lines):
+        buffer.set_position(0, index)
+        buffer.write(line)
+
+    buffer.show(console_handle)
 
 
 def _console_spy(*args, **kwargs):
+    os.system('cls')
     ahk = AHK(directives={NoTrayIcon})
 
     while True:
         position = ahk.mouse_position
         window = Window.from_mouse_position(engine=ahk)
         color = ahk.pixel_get_color(*position)
-        print(f'Mouse Position: {position} Pixel Color: {color} Window Title: {window.title}                ', end='\r')
+        _print_fields(position, color, window.title)
+
+
+class Char(ctypes.Union):
+    _fields_ = [("UnicodeChar", WCHAR), ("AsciiChar", CHAR)]
+
+
+class CHAR_INFO(ctypes.Structure):
+    _anonymous_ = ("Char",)
+    _fields_ = [("Char", Char), ("Attributes", WORD)]
+
+
+class CONSOLE_CURSOR_INFO(ctypes.Structure):
+    _fields_ = [('dwSize', DWORD), ('bVisible', BOOL)]
+
+
+PCHAR_INFO = ctypes.POINTER(CHAR_INFO)
+COORD = wintypes._COORD
+
+
+class CONSOLE_FONT_INFO(ctypes.Structure):
+    _fields_ = [('nFont', DWORD), ('dwFontSize', COORD)]
+
+
+class CONSOLE_SCREEN_BUFFER_INFO(ctypes.Structure):
+    _fields_ = [
+        ('dwSize', COORD),
+        ('dwCursorPosition', COORD),
+        ('wAttributes', WORD),
+        ('srWindow', SMALL_RECT),
+        ('dwMaximumWindowSize', COORD),
+    ]
+
+
+
+Kernel32 = ctypes.WinDLL('Kernel32.dll')
+User32 = ctypes.WinDLL('User32.dll')
+Gdi32 = ctypes.WinDLL('Gdi32.dll')
+
+
+class ConsoleBuffer:
+    def __init__(self, width, height):
+        self.buff = Kernel32.CreateConsoleScreenBuffer(
+            0x80000000 | 0x40000000, 0x00000001 | 0x00000002, None, 1, None
+        )
+        if self.buff == HANDLE(-1):
+            raise RuntimeError("Could not create screen buffer")
+        self.width = width
+        self.height = height
+        self.cursor_info = CONSOLE_CURSOR_INFO()
+        self.cursor_info.dwSize = 25
+        self.buff_size = COORD(width, height)
+        Kernel32.SetConsoleScreenBufferSize(self.buff, self.buff_size)
+        self.buff_start_coord = COORD(0, 0)
+        self.read_region = SMALL_RECT(0, 0, width - 1, height - 1)
+        self.write_region = SMALL_RECT(0, 0, width - 1, height - 1)
+        self.written = DWORD()
+
+    @property
+    def handle(self):
+        return self.buff
+
+    def set_color(self, color):
+        Kernel32.SetConsoleTextAttribute(self.buff, color)
+
+    def set_position(self, x, y, stdout=None):
+        coord = COORD(x, y)
+        if stdout is None:
+            Kernel32.SetConsoleCursorPosition(self.buff, coord)
+        else:
+            Kernel32.SetConsoleCursorPosition(stdout, coord)
+
+    @staticmethod
+    def wrap_text(text, w):
+        return textwrap.fill(text, w, replace_whitespace=False, drop_whitespace=False) + '\n'
+
+    def write(self, msg):
+        msg = self.wrap_text(msg, self.buff_size.X)
+        success = Kernel32.WriteConsoleW(self.buff, msg, DWORD(len(msg)), ctypes.byref(self.written), None)
+
+        if not success:
+            raise RuntimeError('write console failed')
+
+    def show(self, handle):
+        char_buffer = (CHAR_INFO * (self.buff_size.X * self.buff_size.Y))()
+
+        success = Kernel32.ReadConsoleOutputW(
+            self.buff, ctypes.byref(char_buffer), self.buff_size, self.buff_start_coord, ctypes.byref(self.read_region)
+        )
+
+        if not success:
+            raise RuntimeError('Could not read console')
+
+        success = Kernel32.WriteConsoleOutputW(
+            handle, ctypes.byref(char_buffer), self.buff_size, self.buff_start_coord, ctypes.byref(self.write_region)
+        )
+
+        if not success:
+            raise RuntimeError('Could not write console')
+
+
+console_handle = Kernel32.GetStdHandle(DWORD(-11))
+
+if console_handle == HANDLE(-1):
+    raise RuntimeError('could not get buffer handle')
+
+width = User32.GetSystemMetrics(0)
+buffer = ConsoleBuffer(width, 5)
+buffer.set_position(0, 0)
 
 
 def _main():
     try:
         _console_spy()
     except KeyboardInterrupt:
-        print('Exiting.')
+        buffer.set_position(0, 3, console_handle)
+        buffer.write('Exiting.')
+        buffer.show(console_handle)

--- a/ahk/console_spy.py
+++ b/ahk/console_spy.py
@@ -1,0 +1,16 @@
+from ahk import AHK
+from ahk.window import Window
+from ahk.directives import NoTrayIcon
+
+
+def _console_spy(*args, **kwargs):
+    ahk = AHK(directives={NoTrayIcon})
+
+    while True:
+        position = ahk.mouse_position
+        window = Window.from_mouse_position(engine=ahk)
+        color = ahk.pixel_get_color(*position)
+        print(f'Mouse Position: {position} Pixel Color: {color} Window Title: {window.title}                ', end='\r')
+
+def _main():
+    _console_spy()

--- a/ahk/script.py
+++ b/ahk/script.py
@@ -78,6 +78,8 @@ class ScriptEngine(object):
 
             If environment variable not present, tries to look for 'AutoHotkey.exe' or 'AutoHotkeyA32.exe' with shutil.which
 
+        :param directives: additional AHK directives to add to all rendered scripts
+
         :raises ExecutableNotFound: if AHK executable cannot be found or the specified file does not exist
         """
         self.executable_path = _resolve_executable_path(executable_path)
@@ -91,7 +93,7 @@ class ScriptEngine(object):
         Renders a given jinja template and returns a string of script text
 
         :param template_name: the name of the jinja template to render
-        :param directives: additional AHK directives to add to all scripts
+        :param directives: additional AHK directives to add to the resulting script
         :param blocking: whether the template should be rendered to block (use #Persistent directive)
         :param kwargs: keywords passed to template rendering
         :return: An AutoHotkey script as a string

--- a/ahk/script.py
+++ b/ahk/script.py
@@ -65,7 +65,7 @@ def _resolve_executable_path(executable_path: str = ''):
 
 class ScriptEngine(object):
 
-    def __init__(self, executable_path: str = "", **kwargs):
+    def __init__(self, executable_path: str = "", directives=None, **kwargs):
         """
         This class is typically not used directly. AHK components inherit from this class
         and the arguments for this class should usually be passed in to :py:class:`~ahk.AHK`.
@@ -81,7 +81,7 @@ class ScriptEngine(object):
         :raises ExecutableNotFound: if AHK executable cannot be found or the specified file does not exist
         """
         self.executable_path = _resolve_executable_path(executable_path)
-
+        self._directives = directives
         templates_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'templates')
         self.env = Environment(loader=FileSystemLoader(templates_path),
                                autoescape=False, trim_blocks=True)
@@ -91,7 +91,7 @@ class ScriptEngine(object):
         Renders a given jinja template and returns a string of script text
 
         :param template_name: the name of the jinja template to render
-        :param directives: additional AHK directives to add to the resulting script
+        :param directives: additional AHK directives to add to all scripts
         :param blocking: whether the template should be rendered to block (use #Persistent directive)
         :param kwargs: keywords passed to template rendering
         :return: An AutoHotkey script as a string
@@ -111,6 +111,9 @@ class ScriptEngine(object):
             directives.add(Persistent)
         elif Persistent in directives:
             directives.remove(Persistent)
+        if self._directives:
+            for directive in self._directives:
+                directives.add(directive)
 
         kwargs['directives'] = directives
         template = self.env.get_template(template_name)

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,8 @@ print(ahk.mouse_position)  #  (150, 150)
 
 # Examples
 
-Non-exhaustive examples of some of the functions available with this package. Full documentation coming soon!
+Non-exhaustive examples of some of the functions available with this package.  
+For complete list of methods, check out the API docs in the [full documentation](https://ahk.readthedocs.io/en/latest)
 
 ## Mouse
 

--- a/docs/console_spy.rst
+++ b/docs/console_spy.rst
@@ -1,0 +1,22 @@
+"Console Spy"
+=============
+
+.. important::
+   This feature is currently in Alpha. Please report any problems by `opening an issue`_
+
+.. _opening an issue: https://github.com/spyoungtech/ahk/issues/new
+
+
+A small console utility is provided in AHK to help see some coordinates and other basic info.
+You can invoke this tool from the command line::
+
+    console_spy
+
+
+Currently, the utility will display the following:
+
+| The current mouse coordinates
+| The pixel color (as hex) under the mouse cursor
+| The title of the window under the mouse
+
+Use a keyboard interrupt (CTRL+C) to stop the utility.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ ahk Python wrapper documentation
    quickstart
    api/index
    README
+   console_spy
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,8 @@ setup(
     ],
     tests_require=test_requirements,
     include_package_data=True,
-    zip_safe=False
+    zip_safe=False,
+    entry_points={
+        'console_scripts': ['console_spy = ahk.console_spy:_main']
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(
     include_package_data=True,
     zip_safe=False,
     entry_points={
-        'console_scripts': ['console_spy = ahk.console_spy:_main']
+        'console_scripts': ['console_spy = ahk._console_spy:_main']
     }
 )


### PR DESCRIPTION
Two changes:

1. Script engine accepts a `directives` argument that will add those directives to all scripts. This is particularly useful to instantiate AHK with NoTrayIcon directive to prevent the tray icon from flashing on fast calls.

2. Introduces alpha version of console spy feature, which can be used to inspect some information in real-time similar to AHK's window spy.