### PR TITLE
Adding 'delay' and 'press_duration' logic to the 'window/win_send.ahk' AHK template

### DIFF
--- a/ahk/templates/window/win_send.ahk
+++ b/ahk/templates/window/win_send.ahk
@@ -1,6 +1,6 @@
 {% extends "base.ahk" %}
 {% block body %}
-{% if delay %}SetKeyDelay, {{ delay }}{% endif %}
+SetKeyDelay, {{ delay }}, {{ press_duration }}
 
 {% if raw %}ControlSendRaw{% else %}ControlSend{% endif %}, , {{ keys }}, {{ title }}
 {% endblock body %}

--- a/ahk/templates/window/win_send.ahk
+++ b/ahk/templates/window/win_send.ahk
@@ -1,4 +1,6 @@
 {% extends "base.ahk" %}
 {% block body %}
+{% if delay %}SetKeyDelay, {{ delay }}{% endif %}
+
 {% if raw %}ControlSendRaw{% else %}ControlSend{% endif %}, , {{ keys }}, {{ title }}
 {% endblock body %}

--- a/ahk/window.py
+++ b/ahk/window.py
@@ -524,18 +524,6 @@ class Window(object):
         )
         return self.engine.run_script(script, blocking=blocking)
 
-    def click(self, x, y, blocking=False):
-        """
-        Click at an x/y location on the screen.
-        Uses ControlClick
-        https://autohotkey.com/docs/commands/ControlClick.htm
-        """
-        script = self._render_template(
-            'window/win_click.ahk',
-            x=x, y=y, hwnd=f"ahk_id {self.id}"
-        )
-        return self.engine.run_script(script, blocking=blocking)
-
     def __eq__(self, other):
         if not isinstance(other, Window):
             return False

--- a/ahk/window.py
+++ b/ahk/window.py
@@ -508,7 +508,7 @@ class Window(object):
         )
         self.engine.run_script(script)
 
-    def send(self, keys, delay=10, press_duration=-1, raw=False, blocking=False, escape=False):
+    def send(self, keys, delay=10, raw=False, blocking=False, escape=False, press_duration=-1):
         """
         Send keystrokes directly to the window.
         Uses ControlSend

--- a/ahk/window.py
+++ b/ahk/window.py
@@ -508,7 +508,7 @@ class Window(object):
         )
         self.engine.run_script(script)
 
-    def send(self, keys, delay=None, raw=False, blocking=False, escape=False):
+    def send(self, keys, delay=10, press_duration=-1, raw=False, blocking=False, escape=False):
         """
         Send keystrokes directly to the window.
         Uses ControlSend
@@ -519,7 +519,20 @@ class Window(object):
         script = self._render_template(
             'window/win_send.ahk',
             title=f"ahk_id {self.id}",
-            keys=keys, raw=raw, delay=delay, blocking=blocking
+            keys=keys, raw=raw, delay=delay,
+            press_duration=press_duration, blocking=blocking
+        )
+        return self.engine.run_script(script, blocking=blocking)
+
+    def click(self, x, y, blocking=False):
+        """
+        Click at an x/y location on the screen.
+        Uses ControlClick
+        https://autohotkey.com/docs/commands/ControlClick.htm
+        """
+        script = self._render_template(
+            'window/win_click.ahk',
+            x=x, y=y, hwnd=f"ahk_id {self.id}"
         )
         return self.engine.run_script(script, blocking=blocking)
 


### PR DESCRIPTION
`Window.send` has `delay` as a kwarg and was even passing it to the template in the Python logic, but the actual `window/win_send.ahk` template didn't have the conditional logic to set the key delay.