### PR TITLE
add deprecation warnings for renamed registry methods

### DIFF
--- a/ahk/registery.py
+++ b/ahk/registery.py
@@ -3,18 +3,11 @@ import os
 
 
 class RegisteryMixin(ScriptEngine):
-
     def _render_template(self, template_name, *args, **kwargs):
-        return self.render_template(
-            os.path.join("registery", template_name),
-        )
+        return self.render_template(os.path.join("registery", template_name))
 
     def _run_template(self, template_name, *args, **kwargs):
-        script = self._render_template(
-            template_name,
-            *args,
-            **kwargs
-        )
+        script = self._render_template(template_name, *args, **kwargs)
         return self.run_script(script)
 
     def reg_read(self, key_name: str, value_name="") -> str:
@@ -32,11 +25,7 @@ class RegisteryMixin(ScriptEngine):
             Returns:
                 str -- Registery value
             """
-        self._run_template(
-            "reg_read.ahk",
-            key_name=key_name,
-            value_name=value_name
-        )
+        self._run_template("reg_read.ahk", key_name=key_name, value_name=value_name)
 
     def reg_delete(self, key_name: str, value_name="") -> None:
         """Delete registery
@@ -50,11 +39,7 @@ class RegisteryMixin(ScriptEngine):
             Keyword Arguments:
                 value_name {str} -- TODO (default: {""})
             """
-        self._run_template(
-            "reg_delete.ahk",
-            key_name=key_name,
-            value_name=value_name
-        )
+        self._run_template("reg_delete.ahk", key_name=key_name, value_name=value_name)
 
     def reg_write(self, value_type: str, key_name: str, value_name="") -> None:
         """Write registery
@@ -69,12 +54,7 @@ class RegisteryMixin(ScriptEngine):
             Keyword Arguments:
                 value_name {str} -- TODO (default: {""})
             """
-        self._run_template(
-            "reg_write.ahk",
-            value_type=value_type,
-            key_name=key_name,
-            value_name=value_name
-        )
+        self._run_template("reg_write.ahk", value_type=value_type, key_name=key_name, value_name=value_name)
 
     def reg_set_view(self, reg_view: int) -> None:
         """Set registery view
@@ -89,10 +69,7 @@ class RegisteryMixin(ScriptEngine):
         if reg_view not in [32, 64, "32", "64"]:
             raise ValueError("No valid bit, please use 32 or 64")
 
-        self._run_template(
-            "reg_set_view.ahk",
-            reg_view=reg_view,
-        )
+        self._run_template("reg_set_view.ahk", reg_view=reg_view)
 
     def reg_loop(self, reg: str, key_name: str, mode=""):
         """Loop registery
@@ -109,37 +86,44 @@ class RegisteryMixin(ScriptEngine):
         """
         raise NotImplementedError
 
-        self._run_template(
-            "reg_loop.ahk",
-            reg=reg,
-            key_name=key_name,
-            mode=mode
-        )
+        self._run_template("reg_loop.ahk", reg=reg, key_name=key_name, mode=mode)
 
     def read(self, *args, **kwargs):
         import warnings
+
         warnings.warn(
             'read() has been renamed and will be removed in a future version. use reg_read() instead',
-            DeprecationWarning, stacklevel=2)
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.reg_read(*args, **kwargs)
 
     def write(self, *args, **kwargs):
         import warnings
+
         warnings.warn(
             'write() has been renamed and will be removed in a future version. use reg_write() instead',
-            DeprecationWarning, stacklevel=2)
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.reg_write(*args, **kwargs)
 
     def set_view(self, *args, **kwargs):
         import warnings
+
         warnings.warn(
             'set_view() has been renamed and will be removed in a future version. use reg_set_view() instead',
-            DeprecationWarning, stacklevel=2)
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.reg_set_view(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
         import warnings
+
         warnings.warn(
             'delete() has been renamed and will be removed in a future version. use reg_delete() instead',
-            DeprecationWarning, stacklevel=2)
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.reg_delete(*args, **kwargs)

--- a/ahk/registery.py
+++ b/ahk/registery.py
@@ -17,7 +17,7 @@ class RegisteryMixin(ScriptEngine):
         )
         return self.run_script(script)
 
-    def read(self, key_name: str, value_name="") -> str:
+    def reg_read(self, key_name: str, value_name="") -> str:
         """Read registery
 
             Reference:
@@ -38,7 +38,7 @@ class RegisteryMixin(ScriptEngine):
             value_name=value_name
         )
 
-    def delete(self, key_name: str, value_name="") -> None:
+    def reg_delete(self, key_name: str, value_name="") -> None:
         """Delete registery
 
             Reference:
@@ -56,7 +56,7 @@ class RegisteryMixin(ScriptEngine):
             value_name=value_name
         )
 
-    def write(self, value_type: str, key_name: str, value_name="") -> None:
+    def reg_write(self, value_type: str, key_name: str, value_name="") -> None:
         """Write registery
 
             Reference:
@@ -76,7 +76,7 @@ class RegisteryMixin(ScriptEngine):
             value_name=value_name
         )
 
-    def set_view(self, reg_view: int) -> None:
+    def reg_set_view(self, reg_view: int) -> None:
         """Set registery view
 
             Reference:
@@ -94,7 +94,7 @@ class RegisteryMixin(ScriptEngine):
             reg_view=reg_view,
         )
 
-    def loop(self, reg: str, key_name: str, mode=""):
+    def reg_loop(self, reg: str, key_name: str, mode=""):
         """Loop registery
 
         Reference:
@@ -115,3 +115,31 @@ class RegisteryMixin(ScriptEngine):
             key_name=key_name,
             mode=mode
         )
+
+    def read(self, *args, **kwargs):
+        import warnings
+        warnings.warn(
+            'read() has been renamed and will be removed in a future version. use reg_read() instead',
+            warnings.DeprecationWarning, stacklevel=2)
+        return self.reg_read(*args, **kwargs)
+
+    def write(self, *args, **kwargs):
+        import warnings
+        warnings.warn(
+            'write() has been renamed and will be removed in a future version. use reg_write() instead',
+            warnings.DeprecationWarning, stacklevel=2)
+        return self.reg_write(*args, **kwargs)
+
+    def set_view(self, *args, **kwargs):
+        import warnings
+        warnings.warn(
+            'set_view() has been renamed and will be removed in a future version. use reg_set_view() instead',
+            warnings.DeprecationWarning, stacklevel=2)
+        return self.reg_set_view(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        import warnings
+        warnings.warn(
+            'delete() has been renamed and will be removed in a future version. use reg_delete() instead',
+            warnings.DeprecationWarning, stacklevel=2)
+        return self.reg_delete(*args, **kwargs)

--- a/ahk/registery.py
+++ b/ahk/registery.py
@@ -120,26 +120,26 @@ class RegisteryMixin(ScriptEngine):
         import warnings
         warnings.warn(
             'read() has been renamed and will be removed in a future version. use reg_read() instead',
-            warnings.DeprecationWarning, stacklevel=2)
+            DeprecationWarning, stacklevel=2)
         return self.reg_read(*args, **kwargs)
 
     def write(self, *args, **kwargs):
         import warnings
         warnings.warn(
             'write() has been renamed and will be removed in a future version. use reg_write() instead',
-            warnings.DeprecationWarning, stacklevel=2)
+            DeprecationWarning, stacklevel=2)
         return self.reg_write(*args, **kwargs)
 
     def set_view(self, *args, **kwargs):
         import warnings
         warnings.warn(
             'set_view() has been renamed and will be removed in a future version. use reg_set_view() instead',
-            warnings.DeprecationWarning, stacklevel=2)
+            DeprecationWarning, stacklevel=2)
         return self.reg_set_view(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
         import warnings
         warnings.warn(
             'delete() has been renamed and will be removed in a future version. use reg_delete() instead',
-            warnings.DeprecationWarning, stacklevel=2)
+            DeprecationWarning, stacklevel=2)
         return self.reg_delete(*args, **kwargs)


### PR DESCRIPTION
Renames `read`/`write`/`delete`/`set_view` to `reg_read`/`reg_write`/`reg_delete`/`reg_set_view`