### PR TITLE
quotation marks added mode place holder

### DIFF
--- a/ahk/templates/keyboard/key_state.ahk
+++ b/ahk/templates/keyboard/key_state.ahk
@@ -1,6 +1,6 @@
 {% extends "base.ahk" %}
 {% block body %}
-if (GetKeyState("{{ key_name }}"{% if mode %} , {{ mode }}{% endif %})) {
+if (GetKeyState("{{ key_name }}"{% if mode %} , "{{ mode }}"{% endif %})) {
     FileAppend, 1, *
 } else {
     FileAppend, 0, *


### PR DESCRIPTION
key_state was not able to identify a toggled state due to missing quotations around the mode argument. 

modification made to key_state.ahk template