### PR TITLE
Asyncio support (preview)

### DIFF
--- a/ahk/__init__.py
+++ b/ahk/__init__.py
@@ -1,3 +1,3 @@
-from ahk.autohotkey import AHK, ActionChain
+from ahk.autohotkey import AHK, ActionChain, AsyncAHK
 from ahk.keyboard import Hotkey
 __all__ = ['AHK']

--- a/ahk/autohotkey.py
+++ b/ahk/autohotkey.py
@@ -5,7 +5,7 @@ from ahk.mouse import MouseMixin, AsyncMouseMixin
 from ahk.registery import RegisteryMixin#, AsyncRegisteryMixin
 from ahk.screen import ScreenMixin#, AsyncScreenMixin
 from ahk.sound import SoundMixin#, AsyncSoundMixin
-from ahk.window import WindowMixin#, AsyncWindowMixin
+from ahk.window import WindowMixin, AsyncWindowMixin
 from ahk.gui import GUIMixin#, AsyncGUIMixin
 
 
@@ -29,6 +29,7 @@ class AsyncAHK(
     #AsyncWindowMixin,
     AsyncMouseMixin,
     AsyncKeyboardMixin,
+    AsyncWindowMixin
     #AsyncScreenMixin,
     #AsyncSoundMixin,
     #AsyncRegisteryMixin,

--- a/ahk/autohotkey.py
+++ b/ahk/autohotkey.py
@@ -1,12 +1,12 @@
 from collections import deque
 
-from ahk.keyboard import KeyboardMixin
-from ahk.mouse import MouseMixin
-from ahk.registery import RegisteryMixin
-from ahk.screen import ScreenMixin
-from ahk.sound import SoundMixin
-from ahk.window import WindowMixin
-from ahk.gui import GUIMixin
+from ahk.keyboard import KeyboardMixin, AsyncKeyboardMixin
+from ahk.mouse import MouseMixin, AsyncMouseMixin
+from ahk.registery import RegisteryMixin#, AsyncRegisteryMixin
+from ahk.screen import ScreenMixin#, AsyncScreenMixin
+from ahk.sound import SoundMixin#, AsyncSoundMixin
+from ahk.window import WindowMixin#, AsyncWindowMixin
+from ahk.gui import GUIMixin#, AsyncGUIMixin
 
 
 class AHK(WindowMixin, MouseMixin, KeyboardMixin, ScreenMixin, SoundMixin, RegisteryMixin, GUIMixin):
@@ -23,6 +23,18 @@ class AHK(WindowMixin, MouseMixin, KeyboardMixin, ScreenMixin, SoundMixin, Regis
     """
 
     pass
+
+#
+class AsyncAHK(
+    #AsyncWindowMixin,
+    AsyncMouseMixin,
+    AsyncKeyboardMixin,
+    #AsyncScreenMixin,
+    #AsyncSoundMixin,
+    #AsyncRegisteryMixin,
+    #AsyncGUIMixin
+):
+    ...
 
 
 class ActionChain(AHK):

--- a/ahk/autohotkey.py
+++ b/ahk/autohotkey.py
@@ -2,14 +2,14 @@ from collections import deque
 
 from ahk.keyboard import KeyboardMixin, AsyncKeyboardMixin
 from ahk.mouse import MouseMixin, AsyncMouseMixin
-from ahk.registery import RegisteryMixin#, AsyncRegisteryMixin
+from ahk.registry import RegistryMixin, AsyncRegistryMixin
 from ahk.screen import ScreenMixin, AsyncScreenMixin
-from ahk.sound import SoundMixin#, AsyncSoundMixin
+from ahk.sound import SoundMixin, AsyncSoundMixin
 from ahk.window import WindowMixin, AsyncWindowMixin
-from ahk.gui import GUIMixin#, AsyncGUIMixin
+from ahk.gui import GUIMixin, AsyncGUIMixin
 
 
-class AHK(WindowMixin, MouseMixin, KeyboardMixin, ScreenMixin, SoundMixin, RegisteryMixin, GUIMixin):
+class AHK(WindowMixin, MouseMixin, KeyboardMixin, ScreenMixin, SoundMixin, RegistryMixin, GUIMixin):
     """
     Inherits its methods from the following classes:
 
@@ -30,9 +30,9 @@ class AsyncAHK(
     AsyncKeyboardMixin,
     AsyncWindowMixin,
     AsyncScreenMixin,
-    #AsyncSoundMixin,
-    #AsyncRegisteryMixin,
-    #AsyncGUIMixin
+    AsyncSoundMixin,
+    AsyncRegistryMixin,
+    AsyncGUIMixin
 ):
     ...
 

--- a/ahk/autohotkey.py
+++ b/ahk/autohotkey.py
@@ -3,7 +3,7 @@ from collections import deque
 from ahk.keyboard import KeyboardMixin, AsyncKeyboardMixin
 from ahk.mouse import MouseMixin, AsyncMouseMixin
 from ahk.registery import RegisteryMixin#, AsyncRegisteryMixin
-from ahk.screen import ScreenMixin#, AsyncScreenMixin
+from ahk.screen import ScreenMixin, AsyncScreenMixin
 from ahk.sound import SoundMixin#, AsyncSoundMixin
 from ahk.window import WindowMixin, AsyncWindowMixin
 from ahk.gui import GUIMixin#, AsyncGUIMixin
@@ -26,11 +26,10 @@ class AHK(WindowMixin, MouseMixin, KeyboardMixin, ScreenMixin, SoundMixin, Regis
 
 #
 class AsyncAHK(
-    #AsyncWindowMixin,
     AsyncMouseMixin,
     AsyncKeyboardMixin,
-    AsyncWindowMixin
-    #AsyncScreenMixin,
+    AsyncWindowMixin,
+    AsyncScreenMixin,
     #AsyncSoundMixin,
     #AsyncRegisteryMixin,
     #AsyncGUIMixin

--- a/ahk/gui.py
+++ b/ahk/gui.py
@@ -1,4 +1,4 @@
-from ahk.script import ScriptEngine
+from ahk.script import ScriptEngine, AsyncScriptEngine
 
 
 class GUIMixin(ScriptEngine):
@@ -28,13 +28,12 @@ class GUIMixin(ScriptEngine):
         :type id: str, optional
         :raises ValueError: ID must be between [1, 20]
         """
-
         if id and not (1 <= int(id) <= 20):
             raise ValueError("ID value must be between [1, 20]")
 
         encoded_text = "% " + "".join([f"Chr({hex(ord(char))})" for char in text])
         script = self.render_template("gui/tooltip.ahk", text=encoded_text, second=second, x=x, y=y, id=id)
-        self.run_script(script, blocking=blocking)
+        return self.run_script(script, blocking=blocking) or None
 
     def _show_traytip(
         self, title: str, text: str, second=1.0, type_id=1, slient=False, large_icon=False, blocking=True
@@ -63,7 +62,7 @@ class GUIMixin(ScriptEngine):
         script = self.render_template(
             "gui/traytip.ahk", title=encoded_title, text=encoded_text, second=second, option=option
         )
-        self.run_script(script, blocking=blocking)
+        return self.run_script(script, blocking=blocking) or None
 
     def show_info_traytip(self, title: str, text: str, second=1.0, slient=False, large_icon=False, blocking=True):
         """Show TrayTip with info icon (Windows 10 toast notification)
@@ -124,3 +123,7 @@ class GUIMixin(ScriptEngine):
         :type blocked: bool, optional
         """
         return self._show_traytip(title, text, second, self.TRAYTIP_ERROR, slient, large_icon, blocking)
+
+
+class AsyncGUIMixin(AsyncScriptEngine, GUIMixin):
+    pass

--- a/ahk/registry.py
+++ b/ahk/registry.py
@@ -1,8 +1,8 @@
-from ahk.script import ScriptEngine
+from ahk.script import ScriptEngine, AsyncScriptEngine
 import os
 
 
-class RegisteryMixin(ScriptEngine):
+class RegistryMixin(ScriptEngine):
     def _render_template(self, template_name, *args, **kwargs):
         return self.render_template(os.path.join("registery", template_name))
 
@@ -25,7 +25,7 @@ class RegisteryMixin(ScriptEngine):
             Returns:
                 str -- Registery value
             """
-        self._run_template("reg_read.ahk", key_name=key_name, value_name=value_name)
+        return self._run_template("reg_read.ahk", key_name=key_name, value_name=value_name)
 
     def reg_delete(self, key_name: str, value_name="") -> None:
         """Delete registery
@@ -39,7 +39,7 @@ class RegisteryMixin(ScriptEngine):
             Keyword Arguments:
                 value_name {str} -- TODO (default: {""})
             """
-        self._run_template("reg_delete.ahk", key_name=key_name, value_name=value_name)
+        return self._render_template("reg_delete.ahk", key_name=key_name, value_name=value_name)
 
     def reg_write(self, value_type: str, key_name: str, value_name="") -> None:
         """Write registery
@@ -54,7 +54,7 @@ class RegisteryMixin(ScriptEngine):
             Keyword Arguments:
                 value_name {str} -- TODO (default: {""})
             """
-        self._run_template("reg_write.ahk", value_type=value_type, key_name=key_name, value_name=value_name)
+        return self._render_template("reg_write.ahk", value_type=value_type, key_name=key_name, value_name=value_name)
 
     def reg_set_view(self, reg_view: int) -> None:
         """Set registery view
@@ -69,7 +69,7 @@ class RegisteryMixin(ScriptEngine):
         if reg_view not in [32, 64, "32", "64"]:
             raise ValueError("No valid bit, please use 32 or 64")
 
-        self._run_template("reg_set_view.ahk", reg_view=reg_view)
+        return self._run_template("reg_set_view.ahk", reg_view=reg_view) or None
 
     def reg_loop(self, reg: str, key_name: str, mode=""):
         """Loop registery
@@ -86,7 +86,7 @@ class RegisteryMixin(ScriptEngine):
         """
         raise NotImplementedError
 
-        self._run_template("reg_loop.ahk", reg=reg, key_name=key_name, mode=mode)
+        return self._run_template("reg_loop.ahk", reg=reg, key_name=key_name, mode=mode) or None
 
     def read(self, *args, **kwargs):
         import warnings
@@ -127,3 +127,6 @@ class RegisteryMixin(ScriptEngine):
             stacklevel=2,
         )
         return self.reg_delete(*args, **kwargs)
+
+class AsyncRegistryMixin(AsyncScriptEngine, RegistryMixin):
+    pass

--- a/ahk/screen.py
+++ b/ahk/screen.py
@@ -1,47 +1,21 @@
 import ast
-from ahk.script import ScriptEngine
+from ahk.script import ScriptEngine, AsyncScriptEngine
 from typing import Tuple, Union, Optional
 
 
 class ScreenMixin(ScriptEngine):
-    def image_search(self, image_path: str,
-                     upper_bound: Tuple[int, int]=(0, 0), lower_bound: Tuple[int, int]=None,
-                     color_variation: int=None, coord_mode: str='Screen',
-                     scale_height: int=None, scale_width: int=None,
-                     transparent: str=None, icon: int=None) -> Union[Tuple[int, int], None]:
-        """
-        `AutoHotkey ImageSearch reference`_
-
-        .. _AutoHotkey ImageSearch reference: https://autohotkey.com/docs/commands/ImageSearch.htm
-
-
-        :param image_path: path to the image file e.g. C:\location\of\cats.png
-        :param upper_bound: a two-tuple of X,Y coordinates for the upper-left corner of the search area e.g. (200, 400)
-            defaults to (0,0)
-
-        :param lower_bound: like ``upper_bound`` but for the lower-righthand corner of the search area e.g. (400, 800)
-            defaults to screen width and height (lower right-hand corner; ``%A_ScreenWidth%``, ``%A_ScreenHeight%``).
-
-        :param color_variation: Shades of variation (up or down) for the intensity of RGB for each pixel. Equivalent of
-            ``*n`` option. Defaults to 0.
-        
-        :param coord_mode: the Pixel CoordMode to use. Default is 'Screen'
-        :param scale_height: Scale height in pixels. Equivalent of ``*hn`` option
-        :param scale_width: Scale width in pixels. Equivalent of ``*wn`` option
-        :param transparent: Specific color in the image that will be ignored during the search. Pixels with the exact
-            color given will match any color. Can be used with color names e.g. (Black, Purple, Yellow) found
-            at https://https://www.autohotkey.com/docs/commands/Progress.htm#colors or hexadecimal values e.g.
-            (0xFFFFAA, 05FA15, 632511). Equivalent of ``*TransN`` option
-
-        :param icon: Number of the icon group to use. Equivalent of ``*Icon`` option
-
-        :return: coordinates of the upper-left pixel of where the image was found on the screen; ``None`` if the image
-            was not found
-
-        :rtype: Union[Tuple[int, int], None]
-
-        Note: when only scale_height or only scale_width are provided, aspect ratio is maintained by default.
-        """
+    def _image_search(
+        self,
+        image_path: str,
+        upper_bound: Tuple[int, int] = (0, 0),
+        lower_bound: Tuple[int, int] = None,
+        color_variation: int = None,
+        coord_mode: str = 'Screen',
+        scale_height: int = None,
+        scale_width: int = None,
+        transparent: str = None,
+        icon: int = None,
+    ) -> str:
 
         if scale_height and not scale_width:
             scale_width = -1
@@ -64,19 +38,94 @@ class ScreenMixin(ScriptEngine):
             x2, y2 = lower_bound
         else:
             x2, y2 = ('%A_ScreenWidth%', '%A_ScreenHeight%')
-        script = self.render_template('screen/image_search.ahk',
-                                      x1=x1, x2=x2, y1=y1, y2=y2,
-                                      coord_mode=coord_mode,
-                                      image_path=image_path,
-                                      options=options)
+        script = self.render_template(
+            'screen/image_search.ahk',
+            x1=x1,
+            x2=x2,
+            y1=y1,
+            y2=y2,
+            coord_mode=coord_mode,
+            image_path=image_path,
+            options=options,
+        )
+        return script
+
+    def image_search(
+        self,
+        image_path: str,
+        upper_bound: Tuple[int, int] = (0, 0),
+        lower_bound: Tuple[int, int] = None,
+        color_variation: int = None,
+        coord_mode: str = 'Screen',
+        scale_height: int = None,
+        scale_width: int = None,
+        transparent: str = None,
+        icon: int = None,
+    ) -> Union[Tuple[int, int], None]:
+        """
+        `AutoHotkey ImageSearch reference`_
+
+        .. _AutoHotkey ImageSearch reference: https://autohotkey.com/docs/commands/ImageSearch.htm
+
+
+        :param image_path: path to the image file e.g. C:\location\of\cats.png
+        :param upper_bound: a two-tuple of X,Y coordinates for the upper-left corner of the search area e.g. (200, 400)
+            defaults to (0,0)
+
+        :param lower_bound: like ``upper_bound`` but for the lower-righthand corner of the search area e.g. (400, 800)
+            defaults to screen width and height (lower right-hand corner; ``%A_ScreenWidth%``, ``%A_ScreenHeight%``).
+
+        :param color_variation: Shades of variation (up or down) for the intensity of RGB for each pixel. Equivalent of
+            ``*n`` option. Defaults to 0.
+
+        :param coord_mode: the Pixel CoordMode to use. Default is 'Screen'
+        :param scale_height: Scale height in pixels. Equivalent of ``*hn`` option
+        :param scale_width: Scale width in pixels. Equivalent of ``*wn`` option
+        :param transparent: Specific color in the image that will be ignored during the search. Pixels with the exact
+            color given will match any color. Can be used with color names e.g. (Black, Purple, Yellow) found
+            at https://https://www.autohotkey.com/docs/commands/Progress.htm#colors or hexadecimal values e.g.
+            (0xFFFFAA, 05FA15, 632511). Equivalent of ``*TransN`` option
+
+        :param icon: Number of the icon group to use. Equivalent of ``*Icon`` option
+
+        :return: coordinates of the upper-left pixel of where the image was found on the screen; ``None`` if the image
+            was not found
+
+        :rtype: Union[Tuple[int, int], None]
+
+        Note: when only scale_height or only scale_width are provided, aspect ratio is maintained by default.
+        """
+        script = self._image_search(
+            image_path=image_path,
+            upper_bound=upper_bound,
+            lower_bound=lower_bound,
+            color_variation=color_variation,
+            coord_mode=coord_mode,
+            scale_height=scale_height,
+            scale_width=scale_width,
+            transparent=transparent,
+            icon=icon,
+        )
         resp = self.run_script(script)
         try:
             return ast.literal_eval(resp)
         except SyntaxError:
             return None
 
-    def pixel_get_color(self, x: int, y: int, coord_mode: str='Screen',
-                        alt: bool=False, slow: bool=False, rgb=True) -> Union[str, None]:
+    def _pixel_get_color(
+        self, x: int, y: int, coord_mode: str = 'Screen', alt: bool = False, slow: bool = False, rgb=True
+    ):
+        options = []
+        if slow:
+            options.append('Slow')
+        elif alt:
+            options.append('Alt')
+        if rgb:
+            options.append('RGB')
+        script = self.render_template('screen/pixel_get_color.ahk', x=x, y=y, coord_mode=coord_mode, options=options)
+        return script
+
+    def pixel_get_color(self, *args, **kwargs):
         """
         `AutoHotkey PixelGetColor reference`_
 
@@ -89,26 +138,46 @@ class ScreenMixin(ScriptEngine):
         :param slow:
         :param rgb: returns
         :return: the color as an RGB hexidecimal string;
-        :rtype: str
         """
+        script = self._pixel_get_color(*args, **kwargs)
+        return self.run_script(script)
 
+
+    def _pixel_search(
+        self,
+        color: Union[str, int],
+        variation: int = 0,
+        upper_bound: Tuple[int, int] = (0, 0),
+        lower_bound: Tuple[int, int] = None,
+        coord_mode: str = 'Screen',
+        fast: bool = True,
+        rgb: bool = True,
+    ) -> str:
         options = []
-        if slow:
-            options.append('Slow')
-        elif alt:
-            options.append('Alt')
+        if fast:
+            options.append('Fast')
         if rgb:
             options.append('RGB')
-        script = self.render_template('screen/pixel_get_color.ahk',
-                                      x=x, y=y,
-                                      coord_mode=coord_mode,
-                                      options=options)
-        resp = self.run_script(script)
-        return resp
+        x1, y1 = upper_bound
+        if lower_bound:
+            x2, y2 = lower_bound
+        else:
+            x2, y2 = ('%A_ScreenWidth%', '%A_ScreenHeight%')
 
-    def pixel_search(self, color: Union[str, int], variation: int=0,
-                     upper_bound: Tuple[int, int]=(0, 0), lower_bound: Tuple[int, int]=None,
-                     coord_mode: str='Screen', fast: bool=True, rgb: bool=True) -> Union[Tuple[int, int], None]:
+        script = self.render_template(
+            'screen/pixel_search.ahk',
+            x1=x1,
+            y1=y1,
+            x2=x2,
+            y2=y2,
+            coord_mode=coord_mode,
+            color=color,
+            variation=variation,
+            options=options,
+        )
+        return script
+
+    def pixel_search(self, *args, **kwargs):
         """
         `AutoHotkey PixelSearch reference`_
 
@@ -123,24 +192,25 @@ class ScreenMixin(ScriptEngine):
         :param rgb:
         :return: the coordinates of the pixel; None if the pixel is not found
         """
-        options = []
-        if fast:
-            options.append('Fast')
-        if rgb:
-            options.append('RGB')
-        x1, y1 = upper_bound
-        if lower_bound:
-            x2, y2 = lower_bound
-        else:
-            x2, y2 = ('%A_ScreenWidth%', '%A_ScreenHeight%')
-
-        script = self.render_template('screen/pixel_search.ahk',
-                                      x1=x1, y1=y1, x2=x2, y2=y2,
-                                      coord_mode=coord_mode,
-                                      color=color,
-                                      variation=variation,
-                                      options=options)
+        script = self._pixel_search(*args, **kwargs)
         resp = self.run_script(script)
+        try:
+            return ast.literal_eval(resp)
+        except SyntaxError:
+            return None
+
+class AsyncScreenMixin(AsyncScriptEngine, ScreenMixin):
+    async def pixel_search(self, *args, **kwargs):
+        script = self._pixel_search(*args, **kwargs)
+        resp = await self.a_run_script(script)
+        try:
+            return ast.literal_eval(resp)
+        except SyntaxError:
+            return None
+
+    async def image_search(self, *args, **kwargs):
+        script = self._image_search(*args, **kwargs)
+        resp = await self.a_run_script(script)
         try:
             return ast.literal_eval(resp)
         except SyntaxError:

--- a/ahk/script.py
+++ b/ahk/script.py
@@ -219,3 +219,6 @@ class ScriptEngine(object):
             logger.fatal('Error running temp script: %s', e)
             raise
         return result
+
+class AsyncScriptEngine(ScriptEngine):
+    run_script = ScriptEngine.a_run_script

--- a/ahk/sound.py
+++ b/ahk/sound.py
@@ -1,4 +1,4 @@
-from ahk.script import ScriptEngine
+from ahk.script import ScriptEngine, AsyncScriptEngine
 
 
 class SoundMixin(ScriptEngine):
@@ -12,7 +12,7 @@ class SoundMixin(ScriptEngine):
         """
 
         script = self.render_template('sound/beep.ahk', frequency=frequency, duration=duration)
-        self.run_script(script)
+        return self.run_script(script) or None
 
     def sound_play(self, filename, blocking=True):
         """
@@ -25,7 +25,7 @@ class SoundMixin(ScriptEngine):
         """
 
         script = self.render_template('sound/play.ahk', filename=filename, wait=1, blocking=blocking)
-        self.run_script(script, blocking=blocking)
+        return self.run_script(script, blocking=blocking) or None
 
     def sound_get(self, device_number=1, component_type='MASTER', control_type='VOLUME'):
         """
@@ -37,8 +37,7 @@ class SoundMixin(ScriptEngine):
         :param control_type:
         :return:
         """
-
-        script = self.render_template('sound/sound_get.ahk')
+        script = self.render_template('sound/sound_get.ahk', device_number=device_number, component_type=component_type, control_type=control_type)
         return self.run_script(script)
 
     def get_volume(self, device_number=1):
@@ -69,7 +68,7 @@ class SoundMixin(ScriptEngine):
                                       device_number=device_number,
                                       component_type=component_type,
                                       control_type=control_type)
-        self.run_script(script)
+        return self.run_script(script) or None
 
     def set_volume(self, value, device_number=1):
         """
@@ -81,4 +80,8 @@ class SoundMixin(ScriptEngine):
         """
 
         script = self.render_template('sound/set_volume.ahk', value=value, device_number=device_number)
-        self.run_script(script)
+        return self.run_script(script) or None
+
+
+class AsyncSoundMixin(AsyncScriptEngine, SoundMixin):
+    pass

--- a/ahk/templates/window/win_click.ahk
+++ b/ahk/templates/window/win_click.ahk
@@ -1,4 +1,4 @@
 {% extends "base.ahk" %}
 {% block body %}
-ControlClick, x{{ x }} y{{ y }}, {{ hwnd }}
+ControlClick, x{{ x }} y{{ y }}, {{ hwnd }},, {{ button }}, {{ n }}{% if options %}, {{ options }}{% endif %}
 {% endblock body %}

--- a/ahk/templates/window/win_position.ahk
+++ b/ahk/templates/window/win_position.ahk
@@ -1,6 +1,16 @@
 {% extends "base.ahk" %}
 {% block body %}
 WinGetPos, x, y, width, height, {{ title }}
+{% if pos_info %}
+{% if pos_info == "position" %}
+s .= Format("({}, {})", x, y)
+{% elif pos_info == "height" %}
+s .= Format("({})", height)
+{% elif pos_info == "width" %}
+s .= Format("({})", width)
+{% endif %}
+{% else %}
 s .= Format("({}, {}, {}, {})", x, y, width, height)
+{% endif %}
 FileAppend, %s%, *
 {% endblock body %}

--- a/ahk/utils.py
+++ b/ahk/utils.py
@@ -49,28 +49,6 @@ def escape_sequence_replace(s):
     """
     return s.translate(_TRANSLATION_TABLE)
 
-def asyncify(sync_method):
-    cls = sync_method.__class__
-    @functools.wraps(sync_method)
-    async def async_method(self, *args, **kwargs):
-        self_sync_method = getattr(super(self.__class__, self), sync_method.__name__)
-        coro = self_sync_method(*args, **kwargs)
-        return await coro
-    return async_method
-
-class AsyncifyMeta(type):
-    def __new__(typ, *args, **kwargs):
-        cls = super().__new__(typ, *args, **kwargs)
-        asyncifyable = getattr(cls, '_asyncifyable', None)
-        if not asyncifyable:
-            return cls
-
-        for name in asyncifyable:
-            obj = getattr(cls, name)
-            if not callable(obj) or isinstance(obj, type) or isinstance(obj, property):
-                raise ValueError(f'{repr(obj)} object is not asyncifyable)')
-            setattr(cls, f'{name}', asyncify(obj))
-        return cls
 
 async def async_filter(async_pred, iterable):
     for item in iterable:

--- a/ahk/window.py
+++ b/ahk/window.py
@@ -1,8 +1,11 @@
 import ast
+import asyncio
+import collections
 from contextlib import suppress
-
+import warnings
+from types import CoroutineType
 from ahk.script import ScriptEngine
-from ahk.utils import escape_sequence_replace, make_logger
+from ahk.utils import escape_sequence_replace, make_logger, AsyncifyMeta, async_filter
 
 logger = make_logger(__name__)
 
@@ -155,7 +158,7 @@ class Window(object):
             return self.get(attr)
         raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'")
 
-    def get(self, subcommand):
+    def _get(self, subcommand):
         sub = self._get_subcommands.get(subcommand)
         if not sub:
             raise ValueError(f'No such subcommand {subcommand}')
@@ -166,12 +169,16 @@ class Window(object):
             title=f"ahk_id {self.id}",
         )
 
+        return script
+
+    def get(self, subcommand):
+        script = self._get(subcommand)
         return self.engine.run_script(script)
 
     def __repr__(self):
         return f'<ahk.window.Window ahk_id={self.id}>'
 
-    def set(self, subcommand, value):
+    def _set(self, subcommand, value):
         sub = self._set_subcommands.get(subcommand)
         if not sub:
             raise ValueError(f'No such subcommand {subcommand}')
@@ -182,6 +189,10 @@ class Window(object):
             value=value,
             title=f"ahk_id {self.id}"
         )
+        return script
+
+    def set(self, subcommand, value):
+        script = self._set(subcommand, value)
         return self.engine.run_script(script)
 
     def _get_pos(self):
@@ -189,6 +200,15 @@ class Window(object):
             'window/win_position.ahk',
             title=f"ahk_id {self.id}"
         )
+        return script
+
+    def get_pos(self):
+        """
+        Same as ``rect``
+
+        :return:
+        """
+        script = self._get_pos()
         resp = self.engine.run_script(script)
         try:
             value = ast.literal_eval(resp)
@@ -198,7 +218,7 @@ class Window(object):
 
     @property
     def rect(self):
-        return self._get_pos()
+        return self.get_pos()
 
     @rect.setter
     def rect(self, new_position):
@@ -207,7 +227,7 @@ class Window(object):
 
     @property
     def position(self):
-        x, y, _, _ = self._get_pos()
+        x, y, _, _ = self.get_pos()
 
         return x, y
 
@@ -218,7 +238,7 @@ class Window(object):
 
     @property
     def width(self):
-        _, _, width, _ = self._get_pos()
+        _, _, width, _ = self.get_pos()
         return width
 
     @width.setter
@@ -227,19 +247,23 @@ class Window(object):
 
     @property
     def height(self):
-        _, _, _, height = self._get_pos()
+        _, _, _, height = self.get_pos()
         return height
 
     @height.setter
     def height(self, new_height):
         self.move(height=new_height)
 
-    def _base_property(self, command):
+    def _base_check(self, command):
         script = self._render_template(
             "window/base_check.ahk",
             command=command,
             title=f"ahk_id {self.id}"
         )
+        return script
+
+    def _base_property(self, command):
+        script = self._base_check(command)
         resp = self.engine.run_script(script)
         return bool(ast.literal_eval(resp))
 
@@ -247,16 +271,25 @@ class Window(object):
     def active(self):
         return self._base_property(command="WinActive")
 
+    def is_active(self):
+        return self.active
+
     @property
     def exist(self):
         return self._base_property(command="WinExist")
 
-    def _base_get_method(self, command):
+    def exists(self):
+        return self.exist
+
+    def _base_get_method_(self, command):
         script = self._render_template(
             "window/base_get_command.ahk",
             command=command,
             title=f"ahk_id {self.id}"
         )
+        return script
+    def _base_get_method(self, command):
+        script = self._base_get_method_(command)
         result = self.engine.run_script(script, decode=False)
         if self.encoding:
             return result.stdout.decode(encoding=self.encoding)
@@ -266,14 +299,25 @@ class Window(object):
     def title(self):
         return self._base_get_method("WinGetTitle")
 
-    @title.setter
-    def title(self, value):
+    def get_title(self):
+        return self.title
+
+    def _set_title(self, value):
         script = self._render_template(
             "window/win_set_title.ahk",
             title=f"ahk_id {self.id}",
             new_title=value
         )
+        return script
+
+    @title.setter
+    def title(self, value):
+        script = self._set_title(value)
         return self.engine.run_script(script)
+
+    def set_title(self, value):
+        script = self._set_title(value)
+        self.engine.run_script(script)
 
     @property
     def class_name(self):
@@ -291,9 +335,24 @@ class Window(object):
     def maximized(self):
         return self.get("MinMax") == self.MAXIMIZED
 
+    def is_minimized(self):
+        return self.minimized
+
+    def is_maximized(self):
+        return self.maximized
+
     @property
     def non_max_non_min(self):
         return self.get("MinMax") == self.NON_MIN_NON_MAX
+
+    def is_minmax(self):
+        return self.get("MinMax") != self.NON_MIN_NON_MAX
+
+    def get_class_name(self):
+        return self.class_name
+
+    def get_text(self):
+        return self.text
 
     @property
     def transparent(self) -> int:
@@ -303,6 +362,9 @@ class Window(object):
         else:
             return 255
 
+    def get_transparency(self) -> int:
+        return self.transparent
+
     @transparent.setter
     def transparent(self, value):
         if isinstance(value, int) and 0 <= value <= 255:
@@ -311,14 +373,24 @@ class Window(object):
             raise ValueError(
                 f'"{value}" not a valid option. Please use [0, 255] integer')
 
-    @property
-    def always_on_top(self) -> bool:
+    def set_transparency(self, new_value):
+        self.transparent = new_value
+
+    def _always_on_top(self):
         script = self._render_template(
             'window/win_is_always_on_top.ahk',
             title=f"ahk_id {self.id}"
         )
+        return script
+
+    @property
+    def always_on_top(self) -> bool:
+        script = self._always_on_top()
         resp = self.engine.run_script(script)
         return bool(ast.literal_eval(resp))
+
+    def is_always_on_top(self) -> bool:
+        return self.always_on_top
 
     @always_on_top.setter
     def always_on_top(self, value):
@@ -332,13 +404,16 @@ class Window(object):
             raise ValueError(
                 f'"{value}" not a valid option. Please use On/Off/Toggle/True/False/0/1/-1')
 
+    def set_always_on_top(self, value):
+        self.always_on_top = value
+
     def disable(self):
         """
         Distable the window
         
         :return: 
         """
-        self.set('Disable', '')
+        return self.set('Disable', '') or None
 
     def enable(self):
         """
@@ -346,17 +421,17 @@ class Window(object):
         
         :return: 
         """
-        self.set('Enable', '')
+        return self.set('Enable', '') or None
 
     def redraw(self):
-        self.set('Redraw', '')
+        return self.set('Redraw', '') or None
 
     def to_bottom(self):
         """
         Send window to bottom (behind other windows)
         :return:
         """
-        self.set('Bottom', '')
+        return self.set('Bottom', '') or None
 
     def to_top(self):
         """
@@ -364,20 +439,23 @@ class Window(object):
         
         :return: 
         """
-        self.set('Top', '')
+        return self.set('Top', '') or None
 
     def _render_template(self, *args, **kwargs):
         kwargs['win'] = self
         return self.engine.render_template(*args, **kwargs)
 
-    def _base_method(self, command, seconds_to_wait="", blocking=False):
+    def _base_method_(self, command, seconds_to_wait="", blocking=False):
         script = self._render_template(
             "window/base_command.ahk",
             command=command,
             title=f"ahk_id {self.id}",
             seconds_to_wait=seconds_to_wait
         )
+        return script
 
+    def _base_method(self, command, seconds_to_wait="", blocking=False):
+        script = self._base_method_(command, seconds_to_wait=seconds_to_wait)
         return self.engine.run_script(script, blocking=blocking)
 
     def activate(self):
@@ -390,7 +468,7 @@ class Window(object):
 
         :return:
         """
-        self._base_method("WinActivate")
+        return self._base_method("WinActivate") or None
 
     def activate_bottom(self):
         """
@@ -400,7 +478,7 @@ class Window(object):
 
         :return:
         """
-        self._base_method("WinActivateBottom")
+        return self._base_method("WinActivateBottom") or None
 
     def close(self, seconds_to_wait=""):
         """
@@ -411,7 +489,7 @@ class Window(object):
         :param seconds_to_wait:
         :return:
         """
-        self._base_method("WinClose", seconds_to_wait=seconds_to_wait)
+        return self._base_method("WinClose", seconds_to_wait=seconds_to_wait) or None
 
     def hide(self):
         """
@@ -422,10 +500,10 @@ class Window(object):
         
         :return:
         """
-        self._base_method("WinHide")
+        return self._base_method("WinHide") or None
 
     def kill(self, seconds_to_wait=""):
-        self._base_method("WinKill", seconds_to_wait=seconds_to_wait)
+        return self._base_method("WinKill", seconds_to_wait=seconds_to_wait) or None
 
     def maximize(self):
         """
@@ -433,7 +511,7 @@ class Window(object):
         
         :return: 
         """
-        self._base_method("WinMaximize")
+        return self._base_method("WinMaximize") or None
 
     def minimize(self):
         """
@@ -441,7 +519,7 @@ class Window(object):
         
         :return: 
         """
-        self._base_method("WinMinimize")
+        return self._base_method("WinMinimize") or None
 
     def restore(self):
         """
@@ -449,7 +527,7 @@ class Window(object):
         
         :return: 
         """
-        self._base_method("WinRestore")
+        return self._base_method("WinRestore") or None
 
     def show(self):
         """
@@ -457,7 +535,7 @@ class Window(object):
         
         :return: 
         """
-        self._base_method("WinShow")
+        return self._base_method("WinShow") or None
 
     def wait(self, seconds_to_wait=""):
         """
@@ -465,7 +543,7 @@ class Window(object):
         :param seconds_to_wait: 
         :return: 
         """
-        self._base_method("WinWait", seconds_to_wait=seconds_to_wait, blocking=True)
+        return self._base_method("WinWait", seconds_to_wait=seconds_to_wait, blocking=True) or None
 
     def wait_active(self, seconds_to_wait=""):
         """
@@ -473,7 +551,7 @@ class Window(object):
         :param seconds_to_wait: 
         :return: 
         """
-        self._base_method("WinWaitActive", seconds_to_wait=seconds_to_wait, blocking=True)
+        return self._base_method("WinWaitActive", seconds_to_wait=seconds_to_wait, blocking=True) or None
 
     def wait_not_active(self, seconds_to_wait=""):
         """
@@ -481,15 +559,23 @@ class Window(object):
         :param seconds_to_wait: 
         :return: 
         """
-        self._base_method("WinWaitNotActive", seconds_to_wait=seconds_to_wait, blocking=True)
+        return self._base_method("WinWaitNotActive", seconds_to_wait=seconds_to_wait, blocking=True) or None
 
     def wait_close(self, seconds_to_wait=""):
         """
         
-        :param seconds_to_wait: 
+        :param seconds_to_wait:
         :return: 
         """
-        self._base_method("WinWaitClose", seconds_to_wait=seconds_to_wait, blocking=True)
+        return self._base_method("WinWaitClose", seconds_to_wait=seconds_to_wait, blocking=True) or None
+
+    def _move(self, x='', y='', width=None, height=None):
+        script = self._render_template(
+            'window/win_move.ahk',
+            title=f"ahk_id {self.id}",
+            x=x, y=y, width=width, height=height
+        )
+        return script
 
     def move(self, x='', y='', width=None, height=None):
         """
@@ -501,19 +587,10 @@ class Window(object):
         :param height: 
         :return: 
         """
-        script = self._render_template(
-            'window/win_move.ahk',
-            title=f"ahk_id {self.id}",
-            x=x, y=y, width=width, height=height
-        )
+        script = self._move(x=x, y=y, width=width, height=height)
         self.engine.run_script(script)
 
-    def send(self, keys, delay=10, raw=False, blocking=False, escape=False, press_duration=-1):
-        """
-        Send keystrokes directly to the window.
-        Uses ControlSend
-        https://autohotkey.com/docs/commands/Send.htm
-        """
+    def _send(self, keys, delay=10, raw=False, blocking=False, escape=False, press_duration=-1):
         if escape:
             keys = escape_sequence_replace(keys)
         script = self._render_template(
@@ -522,18 +599,51 @@ class Window(object):
             keys=keys, raw=raw, delay=delay,
             press_duration=press_duration, blocking=blocking
         )
+        return script
+
+    def send(self, keys, delay=10, raw=False, blocking=False, escape=False, press_duration=-1):
+        """
+        Send keystrokes directly to the window.
+        Uses ControlSend
+        https://autohotkey.com/docs/commands/Send.htm
+        """
+        script = self._send(keys, delay=delay, raw=raw, blocking=blocking, escape=escape, press_duration=press_duration)
         return self.engine.run_script(script, blocking=blocking)
 
-    def click(self, x, y, blocking=False):
+    def _click(self, x=None, y=None, *, button=None, n=1, options=None, blocking=True):
+        from ahk.mouse import resolve_button
+        if x or y:
+            if y is None and isinstance(x, collections.abc.Sequence) and len(x) == 2:
+                #  alow position to be specified by a sequence of length 2
+                x, y = x
+            assert x is not None and y is not None, 'If provided, position must be specified by x AND y'
+        button = resolve_button(button)
+
+        script = self._render_template(
+            'window/win_click.ahk',
+            x=x, y=y, hwnd=f"ahk_id {self.id}", button=button, n=n, options=options
+        )
+
+        return script
+
+    def click(self, *args, **kwargs):
         """
         Click at an x/y location on the screen.
         Uses ControlClick
         https://autohotkey.com/docs/commands/ControlClick.htm
+
+        x/y position params may also be specified as a 2-item sequence
+
+        :param x: x offset relative to topleft corner of the window
+        :param y: y offset relative to the top of the window
+        :param button: the button to press (default is left mouse)
+        :param n: number of times to click
+        :param options: per ControlClick documentation
+        :param blocking:
+        :return:
         """
-        script = self._render_template(
-            'window/win_click.ahk',
-            x=x, y=y, hwnd=f"ahk_id {self.id}"
-        )
+        blocking = kwargs.get('blocking', True)
+        script = self._click(*args, **kwargs)
         return self.engine.run_script(script, blocking=blocking)
 
     def __eq__(self, other):
@@ -550,8 +660,7 @@ class WindowMixin(ScriptEngine):
         self.window_encoding = kwargs.pop('window_encoding', None)
         super().__init__(*args, **kwargs)
 
-    def win_get(self, title='', text='', exclude_title='', exclude_text='', encoding=None):
-        encoding = encoding or self.window_encoding
+    def _win_get(self, title='', text='', exclude_title='', exclude_text=''):
         script = self.render_template(
             'window/get.ahk',
             subcommand='ID',
@@ -560,8 +669,18 @@ class WindowMixin(ScriptEngine):
             exclude_text=exclude_text,
             exclude_title=exclude_title
         )
+        return script
+
+    def win_get(self, title='', text='', exclude_title='', exclude_text='', encoding=None):
+        script = self._win_get(title=title, text=text, exclude_title=exclude_title, exclude_text=exclude_text, encoding=encoding)
+        encoding = encoding or self.window_encoding
         ahk_id = self.run_script(script)
         return Window(engine=self, ahk_id=ahk_id, encoding=encoding)
+
+    def _win_set(self, subcommand, *args, blocking=True):
+        script = self.render_template(
+            'window/set.ahk',  subcommand=subcommand, *args, blocking=blocking)
+        return script
 
     def win_set(self, subcommand, *args, blocking=True):
         script = self.render_template(
@@ -572,8 +691,14 @@ class WindowMixin(ScriptEngine):
     def active_window(self):
         return self.win_get(title='A')
 
-    def _all_window_ids(self):
+    def get_active_window(self):
+        return self.active_window
+
+    def _all_window_ids_(self):
         script = self.render_template('window/id_list.ahk')
+        return script
+    def _all_window_ids(self):
+        script = self._all_window_ids_()
         result = self.run_script(script)
         return result.split('\n')[:-1]  # last one is always an empty string
 
@@ -687,3 +812,418 @@ class WindowMixin(ScriptEngine):
         """
         with suppress(StopIteration):
             return next(self.find_windows_by_class(*args, **kwargs))
+
+
+class AsyncWindow(Window):
+    # these methods are converted to async compatible versions automatically
+    _asyncifiable = ['disable',
+                    'enable',
+                    'redraw',
+                    'to_bottom',
+                    'to_top',
+                    'activate',
+                    'activate_bottom',
+                    'close',
+                    'hide',
+                    'kill',
+                    'maximize',
+                    'minimize',
+                    'restore',
+                    'show',
+                    'wait',
+                    'wait_active',
+                    'wait_not_active',
+                    'wait_close',
+                    ]
+
+    @classmethod
+    async def from_mouse_position(cls, engine: ScriptEngine, **kwargs):
+        script = engine.render_template('window/from_mouse.ahk')
+        ahk_id = await engine.a_run_script(script)
+        return cls(engine=engine, ahk_id=ahk_id, **kwargs)
+
+    @classmethod
+    async def from_pid(cls, engine: ScriptEngine, pid, **kwargs):
+        script = engine.render_template('window/get.ahk',
+                                        subcommand="ID",
+                                        title=f'ahk_pid {pid}')
+        ahk_id = await engine.a_run_script(script)
+        return cls(engine=engine, ahk_id=ahk_id, **kwargs)
+
+    def __getattr__(self, item):
+        if item in self._get_subcommands:
+            raise AttributeError(f"Unaccessable Attribute. Use get({item}) instead")
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{item}'")
+
+
+    async def get(self, subcommand):
+        script = self._get(subcommand)
+        return await self.engine.a_run_script(script)
+
+    async def set(self, subcommand, value):
+        script = self._set(subcommand, value)
+        await self.engine.a_run_script(script)
+
+    async def get_pos(self):
+        script = self._get_pos()
+        resp = await self.engine.a_run_script(script)
+        try:
+            value = ast.literal_eval(resp)
+            return value
+        except SyntaxError:
+            raise WindowNotFoundError('No window found')
+    @staticmethod
+    async def _loop():
+        return asyncio.get_event_loop()
+
+    @property
+    async def rect(self):
+        warnings.warn("rect property blocks event loop. Use get_rect() instead", stacklevel=2)
+        return await self.get_pos()
+
+    @rect.setter
+    def rect(self, new_position):
+        warnings.warn("rect setter only schedules coroutine. window may not change immediately. Use move() instead", stacklevel=2)
+        x, y, width, height = new_position
+        coro = self.move(x=x, y=y, width=width, height=height)
+        asyncio.create_task(coro)
+
+    @property
+    async def position(self):
+        warnings.warn("position property blocks event loop. Use get_rect() instead", stacklevel=2)
+        x, y, _, _ = await self.get_pos()
+        return x, y
+
+    @position.setter
+    def position(self, new_position):
+        warnings.warn("position setter only schedules coroutine. window may not change immediately. use move() instead", stacklevel=2)
+        x, y = new_position
+        coro = self.move(x, y)
+        asyncio.create_task(coro)
+
+    @property
+    async def width(self):
+        warnings.warn("width property blocks event loop. Use get_rect() instead", stacklevel=2)
+        _, _, width, _ = await self.get_pos()
+        return width
+
+    @width.setter
+    def width(self, new_width):
+        warnings.warn("width setter only schedules coroutine. window may not change immediately. use move() instead", stacklevel=2)
+        coro = self.move(width=new_width)
+        asyncio.create_task(coro)
+
+    @property
+    async def height(self):
+        warnings.warn("height property blocks event loop. Use get_rect() instead", stacklevel=2)
+        _, _, _, height = await self.get_pos()
+        return height
+
+    @height.setter
+    def height(self, new_height):
+        warnings.warn("height setter only schedules coroutine. window may not change immediately. use move() instead", stacklevel=2)
+        coro = self.move(height=new_height)
+        asyncio.create_task(coro)
+
+    async def _base_property(self, command):
+        script = self._base_check(command)
+        resp = await self.engine.a_run_script(script)
+        return bool(ast.literal_eval(resp))
+
+    @property
+    async def active(self):
+        warnings.warn("active property blocks event loop. Use is_active() instead", stacklevel=2)
+        return await self._base_property(command="WinActive")
+    @property
+    async def exist(self):
+        warnings.warn("exist property blocks event loop. Use exists() instead", stacklevel=2)
+        return await self._base_property(command="WinExist")
+
+    async def exists(self):
+        return await self._base_property('WinExist')
+
+    async def _base_get_method(self, command):
+        script = self._base_get_method_(command)
+        result = await self.engine.a_run_script(script, decode=False)
+        if self.encoding:
+            return result.decode(encoding=self.encoding)
+        return result
+
+    @property
+    async def title(self):
+        warnings.warn("title property blocks event loop. Use get_title() instead", stacklevel=2)
+        return await self._base_get_method("WinGetTitle")
+
+    async def get_title(self):
+        await self._base_get_method("WinGetTitle")
+
+    async def set_title(self, value):
+        script = self._set_title(value)
+        await self.engine.a_run_script(script)
+
+    @title.setter
+    def title(self, new_title):
+        warnings.warn("title setter only schedules coroutine. window may not change immediately. use set_title() instead", stacklevel=2)
+        coro = self.set_title(new_title)
+        asyncio.create_task(coro)
+
+    @property
+    async def class_name(self):
+        warnings.warn("class_name property blocks event loop. use get_class_name() instead.")
+        return await self._base_get_method("WinGetClass")
+
+    async def get_class_name(self):
+        return await self._base_get_method("WinGetClass")
+
+    @property
+    async def text(self):
+        warnings.warn("text property blocks event loop. use get_text() instead.")
+        return await self._base_get_method("WinGetText")
+
+    async def get_text(self):
+        return await self._base_get_method("WinGetText")
+
+    @property
+    async def minimized(self):
+        warnings.warn('property blocks event loop. use is_minimized() instead')
+        return await self.get("MinMax") == self.MINIMIZED
+
+    @property
+    async def maximized(self):
+        warnings.warn('property blocks event loop. use is_maximized() instead')
+        return await self.get("MinMax") == self.MAXIMIZED
+
+    async def is_minimized(self):
+        return await self._base_get_method("MinMax") == self.MINIMIZED
+
+    async def is_maximized(self):
+        return await self._base_get_method("MinMax") == self.MAXIMIZED
+
+    @property
+    async def non_max_non_min(self):
+        warnings.warn('property blocks event loop. use is_minmax() instead')
+        return await self.get("MinMax") == self.NON_MIN_NON_MAX
+
+    async def is_minmax(self):
+        return await self.get("MinMax") != self.NON_MIN_NON_MAX
+
+    @property
+    async def transparent(self) -> int:
+        warnings.warn('property blocks event loop. use get_transparency() instead')
+        result = await self.get("Transparent")
+        if result:
+            return int(result)
+        else:
+            return 255
+
+    @transparent.setter
+    def transparent(self, value):
+        warnings.warn("transparent setter only schedules coroutine. window may not change immediately. use set_transparency() instead", stacklevel=2)
+
+        if isinstance(value, int) and 0 <= value <= 255:
+            coro = self.set("Transparent", value)
+            asyncio.create_task(coro)
+        else:
+            raise ValueError('transparency must be integer in range [0, 255]')
+
+    async def get_transparency(self) -> int:
+        result = await self.get("Transparent")
+        if result:
+            return int(result)
+        else:
+            return 255
+
+    async def set_transparency(self, value):
+        if isinstance(value, int) and 0 <= value <= 255:
+            await self.set("Transparent", value)
+        else:
+            raise ValueError(
+                f'"{value}" not a valid option. Please use [0, 255] integer')
+
+    @property
+    async def always_on_top(self) -> bool:
+        warnings.warn("always_on_top property blocks event loop. use is_always_on_top() instead")
+        script = self._always_on_top()
+        resp = await self.engine.a_run_script(script)
+        return bool(ast.literal_eval(resp))
+
+    async def is_always_on_top(self):
+        script = self._always_on_top()
+        resp = self.engine.run_script(script)
+        return bool(ast.literal_eval(resp))
+
+    @always_on_top.setter
+    def always_on_top(self, value):
+        warnings.warn(f"always_on_top setter only schedules coroutine. changes may not happen immediately. use set_always_on_top({repr(value)}) instead")
+        if value in ('on', 'On', True, 1):
+            coro = self.set('AlwaysOnTop', 'On')
+        elif value in ('off', 'Off', False, 0):
+            coro = self.set('AlwaysOnTop', 'Off')
+        elif value in ('toggle', 'Toggle', -1):
+            coro = self.set('AlwaysOnTop', 'Toggle')
+        else:
+            raise ValueError(
+                f'"{value}" not a valid option. Please use On/Off/Toggle/True/False/0/1/-1')
+        asyncio.create_task(coro)
+
+    async def set_always_on_top(self, value):
+        if value in ('on', 'On', True, 1):
+            await self.set('AlwaysOnTop', 'On')
+        elif value in ('off', 'Off', False, 0):
+            await self.set('AlwaysOnTop', 'Off')
+        elif value in ('toggle', 'Toggle', -1):
+            await self.set('AlwaysOnTop', 'Toggle')
+        else:
+            raise ValueError(
+                f'"{value}" not a valid option. Please use On/Off/Toggle/True/False/0/1/-1')
+
+    async def move(self, x='', y='', width=None, height=None):
+        script = self._move(x=x, y=y, width=width, height=height)
+        return await self.engine.a_run_script(script)
+
+    async def send(self, keys, delay=10, raw=False, blocking=True, escape=False, press_duration=-1):
+        script = self._send(keys, delay=delay, raw=raw, blocking=blocking, escape=escape, press_duration=press_duration)
+        return await self.engine.a_run_script(script, blocking=blocking)
+
+    async def activate(self):
+        return await self._base_method("WinActivate")
+
+    async def _base_method(self, command, seconds_to_wait="", blocking=False):
+        script = self._base_method_(command, seconds_to_wait=seconds_to_wait)
+        return await self.engine.a_run_script(script, blocking=blocking)
+
+
+class AsyncWindowMixin(WindowMixin):
+    async def win_get(self, *args, **kwargs):
+        script = self._win_get(*args, **kwargs)
+        encoding = kwargs.get('encoding', self.window_encoding)
+        ahk_id = await self.a_run_script(script)
+        return AsyncWindow(engine=self, ahk_id=ahk_id, encoding=encoding)
+
+    async def win_set(self, subcommand, *args, blocking=True):
+        script = self.render_template(
+            'window/set.ahk',  subcommand=subcommand, *args, blocking=blocking)
+        await self.a_run_script(script, blocking=blocking)
+
+    @property
+    def active_window(self):
+        warnings.warn("active_window property blocks event loop. use get_active_window() instead")
+        return self.win_get(title='A')
+
+    async def _all_window_ids(self):
+        script = self._all_window_ids_()
+        result = await self.a_run_script(script)
+        return result.split('\n')[:-1]  # last one is always an empty string
+
+    async def windows(self):
+        """
+        Returns a list of windows
+
+        :return:
+        """
+        windowze = []
+        for ahk_id in await self._all_window_ids():
+            win = AsyncWindow(engine=self, ahk_id=ahk_id, encoding=self.window_encoding)
+            windowze.append(win)
+        return windowze
+
+    async def find_windows(self, func=None, **kwargs):
+        """
+        Find all matching windows
+
+        :param func: a callable to filter windows
+        :param bool exact: if False (the default) partial matches are found. If True, only exact matches are returned
+        :param kwargs: keywords of attributes of the window (has no effect if ``func`` is provided)
+
+        :return: a generator containing any matching :py:class:`~ahk.window.Window` objects.
+        """
+        if func is None:
+            exact = kwargs.pop('exact', False)
+
+            async def func(win):
+                for attr, expected in kwargs.items():
+                    if exact:
+                        result = await getattr(win, attr) == expected
+                    else:
+                        result = expected in await getattr(win, attr)
+                    if result is False:
+                        return False
+                return True
+        async for window in async_filter(func, await self.windows()):
+            yield window
+
+    async def find_window(self, func=None, **kwargs):
+        """
+        Like ``find_windows`` but only returns the first found window
+
+
+        :param func:
+        :param kwargs:
+        :return: a :py:class:`~ahk.window.Window` object or ``None`` if no matching window is found
+        """
+        async for window in self.find_windows(func=func, **kwargs):
+            return window  # return the first result
+        raise WindowNotFoundError("yikes")
+
+    async def find_windows_by_title(self, title, exact=False):
+        """
+        Equivalent to ``find_windows(title=title)```
+
+        Note that ``title`` is a ``bytes`` object
+
+        :param bytes title:
+        :param exact:
+        :return:
+        """
+        async for window in self.find_windows(title=title, exact=exact):
+            yield window
+
+    async def find_window_by_title(self, title):
+        """
+        Like ``find_windows_by_title`` but only returns the first result.
+
+        :return: a :py:class:`~ahk.window.Window` object or ``None`` if no matching window is found
+        """
+
+        async for window in self.find_windows_by_title():
+            return window
+
+    async def find_windows_by_text(self, text, exact=False):
+        """
+
+        :param text:
+        :param exact:
+        :return: a generator containing any matching :py:class:`~ahk.window.Window` objects.
+        """
+        async for window in self.find_windows(text=text, exact=exact):
+            yield window
+
+    async def find_window_by_text(self, *args, **kwargs):
+        """
+
+        :param args:
+        :param kwargs:
+        :return: a :py:class:`~ahk.window.Window` object or ``None`` if no matching window is found
+        """
+        async for window in self.find_windows_by_text(*args, **kwargs):
+            return window
+
+    async def find_windows_by_class(self, class_name, exact=False):
+        """
+
+        :param class_name:
+        :param exact:
+        :return: a generator containing any matching :py:class:`~ahk.window.Window` objects.
+        """
+        async for window in self.find_windows(class_name=class_name, exact=exact):
+            yield window
+
+    async def find_window_by_class(self, *args, **kwargs):
+        """
+        :param args:
+        :param kwargs:
+        :return: a :py:class:`~ahk.window.Window` object or ``None`` if no matching window is found
+        """
+        async for window in self.find_windows_by_class(*args, **kwargs):
+            return window
+

--- a/ahk/window.py
+++ b/ahk/window.py
@@ -814,7 +814,7 @@ class WindowMixin(ScriptEngine):
             return next(self.find_windows_by_class(*args, **kwargs))
 
 
-class AsyncWindow(Window):
+class AsyncWindow(Window, metaclass=AsyncifyMeta):
     # these methods are converted to async compatible versions automatically
     _asyncifiable = ['disable',
                     'enable',
@@ -1084,9 +1084,6 @@ class AsyncWindow(Window):
     async def send(self, keys, delay=10, raw=False, blocking=True, escape=False, press_duration=-1):
         script = self._send(keys, delay=delay, raw=raw, blocking=blocking, escape=escape, press_duration=press_duration)
         return await self.engine.a_run_script(script, blocking=blocking)
-
-    async def activate(self):
-        return await self._base_method("WinActivate")
 
     async def _base_method(self, command, seconds_to_wait="", blocking=False):
         script = self._base_method_(command, seconds_to_wait=seconds_to_wait)

--- a/ahk/window.py
+++ b/ahk/window.py
@@ -672,7 +672,7 @@ class WindowMixin(ScriptEngine):
         return script
 
     def win_get(self, title='', text='', exclude_title='', exclude_text='', encoding=None):
-        script = self._win_get(title=title, text=text, exclude_title=exclude_title, exclude_text=exclude_text, encoding=encoding)
+        script = self._win_get(title=title, text=text, exclude_title=exclude_title, exclude_text=exclude_text)
         encoding = encoding or self.window_encoding
         ahk_id = self.run_script(script)
         return Window(engine=self, ahk_id=ahk_id, encoding=encoding)
@@ -1092,8 +1092,8 @@ class AsyncWindow(Window, metaclass=AsyncifyMeta):
 
 class AsyncWindowMixin(WindowMixin):
     async def win_get(self, *args, **kwargs):
+        encoding = kwargs.pop('encoding', self.window_encoding)
         script = self._win_get(*args, **kwargs)
-        encoding = kwargs.get('encoding', self.window_encoding)
         ahk_id = await self.a_run_script(script)
         return AsyncWindow(engine=self, ahk_id=ahk_id, encoding=encoding)
 

--- a/ahk/window.py
+++ b/ahk/window.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 import warnings
 from types import CoroutineType
 from ahk.script import ScriptEngine, AsyncScriptEngine
-from ahk.utils import escape_sequence_replace, make_logger, AsyncifyMeta, async_filter
+from ahk.utils import escape_sequence_replace, make_logger, async_filter
 
 logger = make_logger(__name__)
 

--- a/ahk/window.py
+++ b/ahk/window.py
@@ -955,7 +955,7 @@ class AsyncWindow(Window, metaclass=AsyncifyMeta):
         return await self._base_get_method("WinGetTitle")
 
     async def get_title(self):
-        await self._base_get_method("WinGetTitle")
+        return await self._base_get_method("WinGetTitle")
 
     async def set_title(self, value):
         script = self._set_title(value)
@@ -994,10 +994,10 @@ class AsyncWindow(Window, metaclass=AsyncifyMeta):
         return await self.get("MinMax") == self.MAXIMIZED
 
     async def is_minimized(self):
-        return await self._base_get_method("MinMax") == self.MINIMIZED
+        return await self.get("MinMax") == self.MINIMIZED
 
     async def is_maximized(self):
-        return await self._base_get_method("MinMax") == self.MAXIMIZED
+        return await self.get("MinMax") == self.MAXIMIZED
 
     @property
     async def non_max_non_min(self):
@@ -1085,7 +1085,7 @@ class AsyncWindow(Window, metaclass=AsyncifyMeta):
         script = self._send(keys, delay=delay, raw=raw, blocking=blocking, escape=escape, press_duration=press_duration)
         return await self.engine.a_run_script(script, blocking=blocking)
 
-    async def _base_method(self, command, seconds_to_wait="", blocking=False):
+    async def _base_method(self, command, seconds_to_wait="", blocking=True):
         script = self._base_method_(command, seconds_to_wait=seconds_to_wait)
         return await self.engine.a_run_script(script, blocking=blocking)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ cache:
 deploy_script:
   - ps: |
       if ($env:APPVEYOR_REPO_TAG -eq "true") {
-        py -3.7 -m venv deploy_venv
+        py -3.8 -m venv deploy_venv
         .\deploy_venv\Scripts\activate.ps1
         python -m pip install --upgrade pip
         pip install --upgrade wheel

--- a/ci/install.bat
+++ b/ci/install.bat
@@ -1,4 +1,4 @@
-py -3.7 -m venv venv
+py -3.8 -m venv venv
 call venv\Scripts\activate.bat
 python -m pip install --upgrade pip
 python -m pip install --upgrade -r .\ci\ci_requirements.txt

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,9 @@ pip install ahk
 ```
 Requires Python 3.6+
 
-Async API requires Python 3.8+
+[Async API](#async-api) requires Python 3.8+
 
-See also [Non-Python dependencies](#deps)  
+See also [Non-Python dependencies](#non-python-dependencies)  
 
 
 # Usage

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ pip install ahk
 ```
 Requires Python 3.6+
 
+Async API requires Python 3.8+
+
 See also [Non-Python dependencies](#deps)  
 
 
@@ -270,12 +272,48 @@ print(result.stdout)  # b'Hello Data!'
 ```
 
 
-## Experimental features
+## Preview features
 
-Experimental features are things that are minimally functional, (even more) likely to have breaking changes, even 
-for minor releases. 
+Preview features are experimental features that are may not be fully functional. 
+These features are (even more) likely to have breaking changes without warning.
 
 Github issues are provided for convenience to collect feedback on these features.
+
+## Async API
+
+[GH-104]
+
+An async API is provided so functions can be called using `async`/`await`.
+
+For the most part, the async API is identical to that of the normal API, with a few exceptions.
+
+See full API documentation for more information.
+
+
+```python
+from ahk import AsyncAHK
+import asyncio
+ahk = AsyncAHK()
+
+async def main():
+    await ahk.mouse_move(100, 100)
+    x, y = await ahk.get_mouse_position()
+    print(x, y)
+
+asyncio.run(main())
+```
+
+While properties (like `.mouse_position` or `.title` for windows) can be `await`ed, 
+additional methods (like `get_mouse_position()` and `get_title()`) have been added for a more intuitive API.
+
+```python
+ahk = AsyncAHK()
+async def main():
+    pos = ahk.mouse_position  # BAD! Does not work!
+    pos = await ahk.mouse_position # OK. Works, but looks kind of weird 
+    pos = await ahk.get_mouse_position() # GOOD! 
+```
+
 
 
 ### Hotkeys

--- a/docs/README.md
+++ b/docs/README.md
@@ -306,12 +306,26 @@ asyncio.run(main())
 While properties (like `.mouse_position` or `.title` for windows) can be `await`ed, 
 additional methods (like `get_mouse_position()` and `get_title()`) have been added for a more intuitive API.
 
+Property setters have different (probably undesired) behavior 
+in the async API. Instead, you should use a comparable method.  
+If you _do_ use the setters, the invocation is created using `asyncio.create_task()`, which means 
+that the task won't run until control is yielded back to the event loop. For now, this will also raise a warning to the same.
+
+Lastly, while it's possible to pass `blocking=True` in the async API, this sometimes will cause problems. 
+
 ```python
 ahk = AsyncAHK()
 async def main():
     pos = ahk.mouse_position  # BAD! Does not work!
     pos = await ahk.mouse_position # OK. Works, but looks kind of weird 
     pos = await ahk.get_mouse_position() # GOOD! 
+    
+    # You probably don't want to do this
+    ahk.mouse_position = (100, 100) # won't do anything right away. Raises warning
+    print(await ahk.get_mouse_position()) # probably won't be 100,100
+    #Instead, do this:
+    await ahk.mouse_move(100, 100, speed=0)
+    assert await ahk.get_mouse_position() == (100, 100)
 ```
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -281,14 +281,8 @@ Github issues are provided for convenience to collect feedback on these features
 
 ## Async API
 
-[GH-104]
-
-An async API is provided so functions can be called using `async`/`await`.
-
-For the most part, the async API is identical to that of the normal API, with a few exceptions.
-
-See full API documentation for more information.
-
+An async API is provided so functions can be called using `async`/`await`. 
+All the same methods from the synchronous API are available in the async API.
 
 ```python
 from ahk import AsyncAHK
@@ -302,14 +296,15 @@ async def main():
 
 asyncio.run(main())
 ```
+For the most part, the async API is identical to that of the normal API, with a few exceptions:
 
 While properties (like `.mouse_position` or `.title` for windows) can be `await`ed, 
 additional methods (like `get_mouse_position()` and `get_title()`) have been added for a more intuitive API.
 
 Property setters have different (probably undesired) behavior 
-in the async API. Instead, you should use a comparable method.  
-If you _do_ use the setters, the invocation is created using `asyncio.create_task()`, which means 
-that the task won't run until control is yielded back to the event loop. For now, this will also raise a warning to the same.
+in the async API. Instead, you should use a comparable method. If you _do_ use the property setters, the invocation is created using `asyncio.create_task()`, which means 
+that the task won't run until control is yielded back to the event loop. For now, this will also raise a warning to the same.  
+
 
 Lastly, while it's possible to pass `blocking=True` in the async API, this sometimes will cause problems. 
 
@@ -320,14 +315,14 @@ async def main():
     pos = await ahk.mouse_position # OK. Works, but looks kind of weird 
     pos = await ahk.get_mouse_position() # GOOD! 
     
-    # You probably don't want to do this
+    # BAD: You probably don't want to do this
     ahk.mouse_position = (100, 100) # won't do anything right away. Raises warning
     print(await ahk.get_mouse_position()) # probably won't be 100,100
-    #Instead, do this:
+    
+    # GOOD: Instead, do this:
     await ahk.mouse_move(100, 100, speed=0)
     assert await ahk.get_mouse_position() == (100, 100)
 ```
-
 
 
 ### Hotkeys
@@ -337,7 +332,8 @@ async def main():
 Hotkeys now have a primitive implementation. You give it a hotkey (a string the same as in an ahk script, without the `::`) 
 and the body of an AHK script to execute as a response to the hotkey.
 
-
+Right now, only AHK code is supported as callbacks for hotkeys. 
+Support for Python callbacks via the Async API is planned.
 
 ```python
 from ahk import AHK, Hotkey

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ setup(
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     tests_require=test_requirements,
     include_package_data=True,

--- a/tests/unittests/test_keyboard.py
+++ b/tests/unittests/test_keyboard.py
@@ -6,13 +6,13 @@ import time
 from itertools import product
 from unittest import TestCase
 
-from ahk import AHK
-from ahk.keys import ALT, CTRL, KEYS
-
 project_root = os.path.abspath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "../..")
 )
 sys.path.insert(0, project_root)
+
+from ahk import AHK
+from ahk.keys import ALT, CTRL, KEYS
 
 
 class TestKeyboard(TestCase):
@@ -106,8 +106,9 @@ class TestKeys(TestCase):
             self.thread.join(timeout=3)
         if self.ahk.key_state("a"):
             self.ahk.key_up("a")
-        if self.ahk.key_down("Control"):
+        if self.ahk.key_state("Control"):
             self.ahk.key_up("Control")
+        self.ahk.set_capslock_state('off')
 
         notepad = self.ahk.find_window(title=b"Untitled - Notepad")
         if notepad:

--- a/tests/unittests/test_keyboard_async.py
+++ b/tests/unittests/test_keyboard_async.py
@@ -88,7 +88,7 @@ def press_a():
     ahk.key_press("a")
 
 #
-class TestKeys(TestCase):
+class TestKeysAsync(TestCase):
     def setUp(self):
         self.ahk = AsyncAHK()
         self._normal_ahk = AHK()

--- a/tests/unittests/test_keyboard_async.py
+++ b/tests/unittests/test_keyboard_async.py
@@ -1,0 +1,173 @@
+import os
+import subprocess
+import sys
+import threading
+import time
+import asyncio
+from itertools import product
+from unittest import TestCase
+
+
+project_root = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "../..")
+)
+sys.path.insert(0, project_root)
+from ahk import AsyncAHK, AHK
+from ahk.keys import ALT, CTRL, KEYS
+
+
+class TestKeyboard(TestCase):
+    def setUp(self):
+        """
+        Record all open windows
+        :return:
+        """
+        self.ahk = AsyncAHK()
+        #self._normal_ahk = AHK()
+        #self.before_windows = self._normal_ahk.windows()
+        self.p = subprocess.Popen("notepad")
+        time.sleep(1)
+
+    def tearDown(self):
+        self.p.terminate()
+        time.sleep(0.2)
+
+    async def a_window_send(self):
+        notepad = await self.ahk.find_window(title=b"Untitled - Notepad")
+        await notepad.send("hello world")
+        await asyncio.sleep(1)
+        self.assertIn(b'hello world', await notepad.get_text())
+
+    def test_window_send(self):
+        asyncio.run(self.a_window_send())
+        # self.notepad.send("hello world")
+        # time.sleep(1)
+        # self.assertIn(b"hello world", self.notepad.text)
+    #
+
+    async def a_send(self):
+        notepad = await self.ahk.find_window(title=b"Untitled - Notepad")
+        await notepad.activate()
+        await self.ahk.send('hello world')
+        self.assertIn(b'hello world', await notepad.get_text())
+    def test_send(self):
+        asyncio.run(self.a_send())
+        # self.notepad.activate()
+        # self.ahk.send("hello world")
+        # assert b"hello world" in self.notepad.text
+
+    # def test_send_key_mult(self):
+    #     self.notepad.send(KEYS.TAB * 4)
+    #     time.sleep(0.5)
+    #     self.assertEqual(self.notepad.text.count(b"\t"), 4, self.notepad.text)
+    #
+    # def test_send_input(self):
+    #     self.notepad.activate()
+    #     self.ahk.send_input("Hello World")
+    #     assert b"Hello World" in self.notepad.text
+    #
+    # def test_type(self):
+    #     self.notepad.activate()
+    #     self.ahk.type("Hello, World!")
+    #     assert b"Hello, World!" in self.notepad.text
+    #
+    # def test_type_escapes_equals(self):
+    #     """
+    #     https://github.com/spyoungtech/ahk/issues/96
+    #     """
+    #     self.notepad.activate()
+    #     self.ahk.type("=foo")
+    #     assert b"=foo" in self.notepad.text
+    #
+    # def test_sendraw_equals(self):
+    #     """
+    #     https://github.com/spyoungtech/ahk/issues/96
+    #     """
+    #     self.notepad.activate()
+    #     self.ahk.send_raw("=foo")
+    #     assert b"=foo" in self.notepad.text
+    #
+    # def test_set_capslock_state(self):
+    #     self.ahk.set_capslock_state("on")
+    #     assert self.ahk.key_state("CapsLock", "T")
+
+#
+# def a_down():
+#     time.sleep(0.5)
+#     ahk = AHK()
+#     ahk.key_down("a")
+#
+#
+# def release_a():
+#     time.sleep(0.5)
+#     ahk = AHK()
+#     ahk.key_up("a")
+#
+#
+# def press_a():
+#     time.sleep(0.5)
+#     ahk = AHK()
+#     ahk.key_press("a")
+#
+#
+# class TestKeys(TestCase):
+#     def setUp(self):
+#         self.ahk = AHK()
+#         self.thread = None
+#         self.hotkey = None
+#
+#     def tearDown(self):
+#         if self.thread is not None:
+#             self.thread.join(timeout=3)
+#         if self.ahk.key_state("a"):
+#             self.ahk.key_up("a")
+#         if self.ahk.key_down("Control"):
+#             self.ahk.key_up("Control")
+#
+#         notepad = self.ahk.find_window(title=b"Untitled - Notepad")
+#         if notepad:
+#             notepad.close()
+#
+#         if self.hotkey and self.hotkey.running:
+#             self.hotkey.stop()
+#
+#     def test_key_wait_pressed(self):
+#         start = time.time()
+#         self.thread = threading.Thread(target=a_down)
+#         self.thread.start()
+#         self.ahk.key_wait("a", timeout=5)
+#         end = time.time()
+#         assert end - start < 5
+#
+#     def test_key_wait_released(self):
+#         start = time.time()
+#         a_down()
+#         self.thread = threading.Thread(target=release_a)
+#         self.thread.start()
+#         self.ahk.key_wait("a", timeout=2)
+#
+#     def test_key_wait_timeout(self):
+#         self.assertRaises(TimeoutError, self.ahk.key_wait, "f", timeout=1)
+#
+#     def test_key_state_when_not_pressed(self):
+#         self.assertFalse(self.ahk.key_state("a"))
+#
+#     def test_key_state_pressed(self):
+#         self.ahk.key_down("Control")
+#         self.assertTrue(self.ahk.key_state("Control"))
+#
+#     def test_hotkey(self):
+#         self.hotkey = self.ahk.hotkey(hotkey="a", script="Run Notepad")
+#         self.thread = threading.Thread(target=a_down)
+#         self.thread.start()
+#         self.hotkey.start()
+#         time.sleep(1)
+#         self.assertIsNotNone(self.ahk.find_window(title=b"Untitled - Notepad"))
+#
+#     def test_hotkey_stop(self):
+#         self.hotkey = self.ahk.hotkey(hotkey="a", script="Run Notepad")
+#         self.hotkey.start()
+#         assert self.hotkey.running
+#         self.hotkey.stop()
+#         self.ahk.key_press("a")
+#         self.assertIsNone(self.ahk.find_window(title=b"Untitled - Notepad"))

--- a/tests/unittests/test_keyboard_async.py
+++ b/tests/unittests/test_keyboard_async.py
@@ -5,7 +5,7 @@ import threading
 import time
 import asyncio
 from itertools import product
-from unittest import TestCase
+from unittest import TestCase, IsolatedAsyncioTestCase
 
 
 project_root = os.path.abspath(
@@ -14,7 +14,7 @@ project_root = os.path.abspath(
 sys.path.insert(0, project_root)
 from ahk import AsyncAHK, AHK
 from ahk.keys import ALT, CTRL, KEYS
-
+a
 
 class TestKeyboardAsync(TestCase):
     def setUp(self):
@@ -33,62 +33,50 @@ class TestKeyboardAsync(TestCase):
         time.sleep(0.2)
         asyncio.run(asyncio.sleep(0.2))
 
-    async def a_window_send(self):
+    async def test_window_send(self):
         notepad = await self.ahk.find_window(title=b"Untitled - Notepad")
         await notepad.send("hello world")
         await asyncio.sleep(1)
         self.assertIn(b'hello world', await notepad.get_text())
 
-    def test_window_send(self):
-        asyncio.run(self.a_window_send())
-
-
-    async def a_send(self):
+    async def test_send(self):
         notepad = await self.ahk.find_window(title=b"Untitled - Notepad")
         await notepad.activate()
         await self.ahk.send('hello world')
         self.assertIn(b'hello world', await notepad.get_text())
-    def test_send(self):
-        asyncio.run(self.a_send())
 
-    async def a_send_input(self):
+    async def test_send_input(self):
         notepad = await self.ahk.find_window(title=b"Untitled - Notepad")
         await self.ahk.send_input("Hello World")
         await asyncio.sleep(0.5)
         assert b"Hello World" in await notepad.get_text()
 
-    def test_send_input(self):
-        asyncio.run(self.a_send_input())
-
-    async def a_type(self):
+    async def test_type(self):
         notepad = await self.ahk.find_window(title=b"Untitled - Notepad")
         await notepad.activate()
         await self.ahk.type("Hello, World!")
         assert b"Hello, World!" in await notepad.get_text()
 
-    def test_type(self):
-        asyncio.run(self.a_type())
 
-#
 def a_down():
-    time.sleep(0.5)
+    #time.sleep(0.5)
     ahk = AHK()
     ahk.key_down("a")
 
 
 def release_a():
-    time.sleep(0.5)
+    #time.sleep(0.5)
     ahk = AHK()
     ahk.key_up("a")
 
 
 def press_a():
-    time.sleep(0.5)
+    #time.sleep(0.5)
     ahk = AHK()
     ahk.key_press("a")
 
 #
-class TestKeysAsync(TestCase):
+class TestKeysAsync(IsolatedAsyncioTestCase):
     def setUp(self):
         self.ahk = AsyncAHK()
         self._normal_ahk = AHK()
@@ -103,9 +91,9 @@ class TestKeysAsync(TestCase):
         if self._normal_ahk.key_state("Control"):
             self._normal_ahk.key_up("Control")
 
-        notepad = self.ahk.find_window(title=b"Untitled - Notepad")
+        notepad = self._normal_ahk.find_window(title=b"Untitled - Notepad")
         if notepad:
-            notepad.close()
+            notepad.kill()
 
         if self.hotkey and self.hotkey.running:
             self.hotkey.stop()
@@ -134,24 +122,20 @@ class TestKeysAsync(TestCase):
         assert end - start < 2
 
     async def a_key_wait_timeout(self):
-        await self.ahk.key_wait('f', timeout=1)
+        await self.ahk.key_wait('f', timeout=0.1)
 
     def test_key_wait_timeout(self):
         self.assertRaises(TimeoutError, asyncio.run, self.a_key_wait_timeout())
 
 
-    async def a_key_state_when_not_pressed(self):
-        return await self.ahk.key_state("a")
+    async def test_key_state_when_not_pressed(self):
+        self.assertFalse(await self.ahk.key_state("a"))
 
-    def test_key_state_when_not_pressed(self):
-        self.assertFalse(asyncio.run(self.a_key_state_when_not_pressed()))
-#
-    async def a_key_state_pressed(self):
+
+    async def test_key_state_pressed(self):
         await self.ahk.key_down("Control")
         self.assertTrue(await self.ahk.key_state("Control"))
 
-    def test_key_state_pressed(self):
-        asyncio.run(self.a_key_state_pressed())
 
 #     def test_hotkey(self):
 #         self.hotkey = self.ahk.hotkey(hotkey="a", script="Run Notepad")

--- a/tests/unittests/test_keyboard_async.py
+++ b/tests/unittests/test_keyboard_async.py
@@ -59,19 +59,19 @@ class TestKeyboardAsync(TestCase):
 
 
 def a_down():
-    #time.sleep(0.5)
+    time.sleep(0.5)
     ahk = AHK()
     ahk.key_down("a")
 
 
 def release_a():
-    #time.sleep(0.5)
+    time.sleep(0.5)
     ahk = AHK()
     ahk.key_up("a")
 
 
 def press_a():
-    #time.sleep(0.5)
+    time.sleep(0.5)
     ahk = AHK()
     ahk.key_press("a")
 

--- a/tests/unittests/test_keyboard_async.py
+++ b/tests/unittests/test_keyboard_async.py
@@ -16,7 +16,7 @@ from ahk import AsyncAHK, AHK
 from ahk.keys import ALT, CTRL, KEYS
 
 
-class TestKeyboard(TestCase):
+class TestKeyboardAsync(TestCase):
     def setUp(self):
         """
         Record all open windows
@@ -41,10 +41,7 @@ class TestKeyboard(TestCase):
 
     def test_window_send(self):
         asyncio.run(self.a_window_send())
-        # self.notepad.send("hello world")
-        # time.sleep(1)
-        # self.assertIn(b"hello world", self.notepad.text)
-    #
+
 
     async def a_send(self):
         notepad = await self.ahk.find_window(title=b"Untitled - Notepad")
@@ -53,110 +50,109 @@ class TestKeyboard(TestCase):
         self.assertIn(b'hello world', await notepad.get_text())
     def test_send(self):
         asyncio.run(self.a_send())
-        # self.notepad.activate()
-        # self.ahk.send("hello world")
-        # assert b"hello world" in self.notepad.text
 
-    # def test_send_key_mult(self):
-    #     self.notepad.send(KEYS.TAB * 4)
-    #     time.sleep(0.5)
-    #     self.assertEqual(self.notepad.text.count(b"\t"), 4, self.notepad.text)
-    #
-    # def test_send_input(self):
-    #     self.notepad.activate()
-    #     self.ahk.send_input("Hello World")
-    #     assert b"Hello World" in self.notepad.text
-    #
-    # def test_type(self):
-    #     self.notepad.activate()
-    #     self.ahk.type("Hello, World!")
-    #     assert b"Hello, World!" in self.notepad.text
-    #
-    # def test_type_escapes_equals(self):
-    #     """
-    #     https://github.com/spyoungtech/ahk/issues/96
-    #     """
-    #     self.notepad.activate()
-    #     self.ahk.type("=foo")
-    #     assert b"=foo" in self.notepad.text
-    #
-    # def test_sendraw_equals(self):
-    #     """
-    #     https://github.com/spyoungtech/ahk/issues/96
-    #     """
-    #     self.notepad.activate()
-    #     self.ahk.send_raw("=foo")
-    #     assert b"=foo" in self.notepad.text
-    #
-    # def test_set_capslock_state(self):
-    #     self.ahk.set_capslock_state("on")
-    #     assert self.ahk.key_state("CapsLock", "T")
+    async def a_send_input(self):
+        notepad = await self.ahk.find_window(title=b"Untitled - Notepad")
+        await self.ahk.send_input("Hello World")
+        await asyncio.sleep(0.5)
+        assert b"Hello World" in await notepad.get_text()
+
+    def test_send_input(self):
+        asyncio.run(self.a_send_input())
+
+    async def a_type(self):
+        notepad = await self.ahk.find_window(title=b"Untitled - Notepad")
+        await notepad.activate()
+        await self.ahk.type("Hello, World!")
+        assert b"Hello, World!" in await notepad.get_text()
+
+    def test_type(self):
+        asyncio.run(self.a_type())
 
 #
-# def a_down():
-#     time.sleep(0.5)
-#     ahk = AHK()
-#     ahk.key_down("a")
+def a_down():
+    time.sleep(0.5)
+    ahk = AHK()
+    ahk.key_down("a")
+
+
+def release_a():
+    time.sleep(0.5)
+    ahk = AHK()
+    ahk.key_up("a")
+
+
+def press_a():
+    time.sleep(0.5)
+    ahk = AHK()
+    ahk.key_press("a")
+
 #
+class TestKeys(TestCase):
+    def setUp(self):
+        self.ahk = AsyncAHK()
+        self._normal_ahk = AHK()
+        self.thread = None
+        self.hotkey = None
+
+    def tearDown(self):
+        if self.thread is not None:
+            self.thread.join(timeout=3)
+        if self._normal_ahk.key_state("a"):
+            self._normal_ahk.key_up("a")
+        if self._normal_ahk.key_state("Control"):
+            self._normal_ahk.key_up("Control")
+
+        notepad = self.ahk.find_window(title=b"Untitled - Notepad")
+        if notepad:
+            notepad.close()
+
+        if self.hotkey and self.hotkey.running:
+            self.hotkey.stop()
+
+    async def a_key_wait_pressed(self):
+        await self.ahk.key_wait("a", timeout=5)
+
+    def test_key_wait_pressed(self):
+        start = time.time()
+        self.thread = threading.Thread(target=a_down)
+        self.thread.start()
+        asyncio.run(self.a_key_wait_pressed())
+        end = time.time()
+        assert end - start < 5
+
+    async def a_key_wait_released(self):
+        await self.ahk.key_wait("a", timeout=2)
+
+    def test_key_wait_released(self):
+        start = time.time()
+        a_down()
+        self.thread = threading.Thread(target=release_a)
+        self.thread.start()
+        asyncio.run(self.a_key_wait_released())
+        end = time.time()
+        assert end - start < 2
+
+    async def a_key_wait_timeout(self):
+        await self.ahk.key_wait('f', timeout=1)
+
+    def test_key_wait_timeout(self):
+        self.assertRaises(TimeoutError, asyncio.run, self.a_key_wait_timeout())
+
+
+    async def a_key_state_when_not_pressed(self):
+        return await self.ahk.key_state("a")
+
+    def test_key_state_when_not_pressed(self):
+        self.assertFalse(asyncio.run(self.a_key_state_when_not_pressed()))
 #
-# def release_a():
-#     time.sleep(0.5)
-#     ahk = AHK()
-#     ahk.key_up("a")
-#
-#
-# def press_a():
-#     time.sleep(0.5)
-#     ahk = AHK()
-#     ahk.key_press("a")
-#
-#
-# class TestKeys(TestCase):
-#     def setUp(self):
-#         self.ahk = AHK()
-#         self.thread = None
-#         self.hotkey = None
-#
-#     def tearDown(self):
-#         if self.thread is not None:
-#             self.thread.join(timeout=3)
-#         if self.ahk.key_state("a"):
-#             self.ahk.key_up("a")
-#         if self.ahk.key_down("Control"):
-#             self.ahk.key_up("Control")
-#
-#         notepad = self.ahk.find_window(title=b"Untitled - Notepad")
-#         if notepad:
-#             notepad.close()
-#
-#         if self.hotkey and self.hotkey.running:
-#             self.hotkey.stop()
-#
-#     def test_key_wait_pressed(self):
-#         start = time.time()
-#         self.thread = threading.Thread(target=a_down)
-#         self.thread.start()
-#         self.ahk.key_wait("a", timeout=5)
-#         end = time.time()
-#         assert end - start < 5
-#
-#     def test_key_wait_released(self):
-#         start = time.time()
-#         a_down()
-#         self.thread = threading.Thread(target=release_a)
-#         self.thread.start()
-#         self.ahk.key_wait("a", timeout=2)
-#
-#     def test_key_wait_timeout(self):
-#         self.assertRaises(TimeoutError, self.ahk.key_wait, "f", timeout=1)
-#
-#     def test_key_state_when_not_pressed(self):
-#         self.assertFalse(self.ahk.key_state("a"))
-#
-#     def test_key_state_pressed(self):
-#         self.ahk.key_down("Control")
-#         self.assertTrue(self.ahk.key_state("Control"))
-#
+    async def a_key_state_pressed(self):
+        await self.ahk.key_down("Control")
+        self.assertTrue(await self.ahk.key_state("Control"))
+
+    def test_key_state_pressed(self):
+        asyncio.run(self.a_key_state_pressed())
+
 #     def test_hotkey(self):
 #         self.hotkey = self.ahk.hotkey(hotkey="a", script="Run Notepad")
 #         self.thread = threading.Thread(target=a_down)

--- a/tests/unittests/test_keyboard_async.py
+++ b/tests/unittests/test_keyboard_async.py
@@ -31,6 +31,7 @@ class TestKeyboard(TestCase):
     def tearDown(self):
         self.p.terminate()
         time.sleep(0.2)
+        asyncio.run(asyncio.sleep(0.2))
 
     async def a_window_send(self):
         notepad = await self.ahk.find_window(title=b"Untitled - Notepad")

--- a/tests/unittests/test_keyboard_async.py
+++ b/tests/unittests/test_keyboard_async.py
@@ -14,7 +14,7 @@ project_root = os.path.abspath(
 sys.path.insert(0, project_root)
 from ahk import AsyncAHK, AHK
 from ahk.keys import ALT, CTRL, KEYS
-a
+
 
 class TestKeyboardAsync(TestCase):
     def setUp(self):

--- a/tests/unittests/test_mouse.py
+++ b/tests/unittests/test_mouse.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+import sys
+import threading
+import time
+import asyncio
+from itertools import product
+from unittest import TestCase, IsolatedAsyncioTestCase
+project_root = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "../..")
+)
+sys.path.insert(0, project_root)
+from ahk import AsyncAHK, AHK
+
+class TestMouse(TestCase):
+    def setUp(self) -> None:
+        self.ahk = AHK()
+
+    def test_mouse_move(self):
+        x, y = self.ahk.mouse_position
+        self.ahk.mouse_move(10, 10, relative=True)
+        assert self.ahk.mouse_position == (x+10, y+10)
+
+class TestMouseAsync(IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.ahk = AsyncAHK()
+
+    async def test_mouse_move(self):
+        x, y = await self.ahk.mouse_position
+        await self.ahk.mouse_move(10, 10, relative=True)
+        assert await self.ahk.mouse_position == (x+10, y+10)
+
+

--- a/tests/unittests/test_screen_async.py
+++ b/tests/unittests/test_screen_async.py
@@ -31,16 +31,16 @@ class TestScreen(IsolatedAsyncioTestCase):
                 await win.close()
                 break
 
-    def test_pixel_search(self):
+    async def test_pixel_search(self):
         result = await self.ahk.pixel_search(0xFF0000)
         self.assertIsNotNone(result)
 
-    def test_image_search(self):
+    async def test_image_search(self):
         self.im.save('testimage.png')
         position = await self.ahk.image_search('testimage.png')
         self.assertIsNotNone(position)
 
-    def test_pixel_get_color(self):
+    async def test_pixel_get_color(self):
         x, y = await self.ahk.pixel_search(0xFF0000)
         result = await self.ahk.pixel_get_color(x, y)
         self.assertIsNotNone(result)

--- a/tests/unittests/test_screen_async.py
+++ b/tests/unittests/test_screen_async.py
@@ -26,7 +26,7 @@ class TestScreen(IsolatedAsyncioTestCase):
         time.sleep(2)
 
     async def asyncTearDown(self):
-        async for win in await self.ahk.windows():
+        for win in await self.ahk.windows():
             if win not in self.before_windows:
                 await win.close()
                 break

--- a/tests/unittests/test_screen_async.py
+++ b/tests/unittests/test_screen_async.py
@@ -1,0 +1,47 @@
+import asyncio
+import sys
+import os
+project_root = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../..'))
+sys.path.insert(0, project_root)
+from ahk import AHK, AsyncAHK
+from unittest import TestCase, IsolatedAsyncioTestCase
+from PIL import Image
+from itertools import product
+import time
+
+
+class TestScreen(IsolatedAsyncioTestCase):
+    def setUp(self):
+        """
+        Record all open windows
+        :return:
+        """
+        self.ahk = AsyncAHK()
+        self.before_windows = asyncio.run(self.ahk.windows())
+        im = Image.new('RGB', (20, 20))
+        for coord in product(range(20), range(20)):
+            im.putpixel(coord, (255, 0, 0))
+        self.im = im
+        im.show()
+        time.sleep(2)
+
+    async def asyncTearDown(self):
+        async for win in await self.ahk.windows():
+            if win not in self.before_windows:
+                await win.close()
+                break
+
+    def test_pixel_search(self):
+        result = await self.ahk.pixel_search(0xFF0000)
+        self.assertIsNotNone(result)
+
+    def test_image_search(self):
+        self.im.save('testimage.png')
+        position = await self.ahk.image_search('testimage.png')
+        self.assertIsNotNone(position)
+
+    def test_pixel_get_color(self):
+        x, y = await self.ahk.pixel_search(0xFF0000)
+        result = await self.ahk.pixel_get_color(x, y)
+        self.assertIsNotNone(result)
+        self.assertEqual(int(result, 16), 0xFF0000)

--- a/tests/unittests/test_win_get_async.py
+++ b/tests/unittests/test_win_get_async.py
@@ -1,0 +1,43 @@
+import asyncio
+import sys
+import os
+import time
+project_root = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../..'))
+sys.path.insert(0, project_root)
+from ahk import AHK, AsyncAHK
+from ahk.window import WindowNotFoundError
+import pytest
+import subprocess
+from unittest import IsolatedAsyncioTestCase
+
+class TestWinGetAsync(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.ahk = AsyncAHK()
+        self.p = subprocess.Popen('notepad')
+        time.sleep(1)
+        self.win = asyncio.run(self.ahk.win_get(title='Untitled - Notepad'))
+        self.assertIsNotNone(self.win)
+
+    def tearDown(self):
+        self.p.terminate()
+        asyncio.run(asyncio.sleep(0.5))
+
+
+    async def test_get_calculator(self):
+        assert await self.win.position
+
+    async def a_win_get(self):
+        win = await self.ahk.win_get(title='Untitled - Notepad')
+        await win.position
+
+    def test_win_close(self):
+        asyncio.run(self.win.close())
+        self.assertRaises(WindowNotFoundError, asyncio.run, self.a_win_get())
+
+    async def test_find_window_func(self):
+        async def func(win):
+            return b'Untitled' in await win.title
+        assert self.win == await self.ahk.find_window(func=func)
+
+    async def test_getattr_window_subcommand(self):
+        assert isinstance(await self.win.pid, str)

--- a/tests/unittests/test_window_async.py
+++ b/tests/unittests/test_window_async.py
@@ -1,0 +1,114 @@
+import subprocess
+import time
+from unittest import TestCase
+import asyncio
+import os
+import sys
+project_root = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "../..")
+)
+sys.path.insert(0, project_root)
+from ahk import AHK, AsyncAHK
+from ahk.window import AsyncWindow
+
+
+class TestWindowAsync(TestCase):
+    win: AsyncWindow
+    def setUp(self):
+        self.ahk = AsyncAHK()
+        self.p = subprocess.Popen('notepad')
+        time.sleep(1)
+        self.win = asyncio.run(self.ahk.win_get(title='Untitled - Notepad'))
+        self.assertIsNotNone(self.win)
+
+    async def a_transparent(self):
+        self.assertEqual(await self.win.get_transparency(), 255)
+
+        self.win.transparent = 220
+        self.assertEqual(await self.win.get_transparency(), 220)
+
+        self.win.transparent = 255
+        self.assertEqual(await self.win.transparent, 255)
+
+
+    def test_transparent(self):
+        asyncio.run(self.a_transparent())
+#
+    def test_pinned(self):
+        asyncio.run(self.a_pinned())
+    async def a_pinned(self):
+        self.assertFalse(await self.win.always_on_top)
+
+        await self.win.set_always_on_top(True)
+        self.assertTrue(await self.win.is_always_on_top())
+
+        self.win.always_on_top = False
+        await asyncio.sleep(1)
+        self.assertFalse(await self.win.always_on_top)
+
+    async def a_close(self):
+        await self.win.close()
+        await asyncio.sleep(0.2)
+        self.assertFalse(await self.win.exists())
+        self.assertFalse(await self.win.exist)
+
+    def test_close(self):
+        asyncio.run(self.a_close())
+
+    async def a_show_hide(self):
+        await self.win.hide()
+        await asyncio.sleep(0.5)
+        self.assertFalse(await self.win.exist)
+
+        await self.win.show()
+        await asyncio.sleep(0.5)
+        self.assertTrue(await self.win.exist)
+
+    def test_show_hide(self):
+        asyncio.run(self.a_show_hide())
+
+    async def a_kill(self):
+        await self.win.kill()
+        await asyncio.sleep(0.5)
+        self.assertFalse(await self.win.exist)
+
+    def test_kill(self):
+        asyncio.run(self.a_kill())
+
+    async def a_max_min(self):
+        self.assertTrue(await self.win.non_max_non_min)
+        self.assertFalse(await self.win.is_minmax())
+
+        await self.win.maximize()
+        await asyncio.sleep(1)
+        self.assertTrue(await self.win.maximized)
+        self.assertTrue(await self.win.is_maximized())
+
+        await self.win.minimize()
+        await asyncio.sleep(1)
+        self.assertTrue(await self.win.minimized)
+        self.assertTrue(await self.win.is_minimized())
+
+        await self.win.restore()
+        await asyncio.sleep(0.5)
+        self.assertTrue(await self.win.maximized)
+        self.assertTrue(await self.win.is_maximized())
+    def test_max_min(self):
+        asyncio.run(self.a_max_min())
+#
+    async def a_names(self):
+        self.assertEqual(await self.win.class_name, b'Notepad')
+        self.assertEqual(await self.win.get_class_name(), b'Notepad')
+
+        self.assertEqual(await self.win.title, b'Untitled - Notepad')
+        self.assertEqual(await self.win.get_title(), b'Untitled - Notepad')
+
+        self.assertEqual(await self.win.text, b'')
+        self.assertEqual(await self.win.get_text(), b'')
+
+
+    def test_names(self):
+        asyncio.run(self.a_names())
+#
+    def tearDown(self):
+        self.p.terminate()

--- a/tests/unittests/test_window_async.py
+++ b/tests/unittests/test_window_async.py
@@ -112,3 +112,4 @@ class TestWindowAsync(TestCase):
 #
     def tearDown(self):
         self.p.terminate()
+        asyncio.run(asyncio.sleep(0.5))


### PR DESCRIPTION
Adds base asyncio support.

While the existing user-facing APIs remains mostly untouched, there are some significant and potentially breaking changes in the PR:

* Default parameter of `blocking` for a couple functions is changed from `False` to `True`  
* Internal API has shifted around quite a bit. Template generation and script running have been split in all (or most) methods  
* Typos in classes and modules were corrected (registry.py and RegistryMixin)


Still to come (in future PRs):

* async hotkeys with Python callbacks!
* A performance-optimized "daemon" mode, where commands are run in a single process, instead of invoking a new process for each AHK command