### PR TITLE
Daemon mode

### DIFF
--- a/ahk/daemon.py
+++ b/ahk/daemon.py
@@ -1,0 +1,99 @@
+import os
+import asyncio
+from ahk.autohotkey import AsyncAHK
+
+class AHKDaemon(AsyncAHK):
+    proc: asyncio.subprocess.Process
+    _template_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'templates')
+    _template = os.path.join(_template_path, 'daemon.ahk')
+    _template_overrides = os.listdir(f'{_template_path}/daemon')
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.queue = asyncio.Queue()
+        self.result_queue = asyncio.Queue()
+        self.proc: asyncio.subprocess.Process
+        self.proc = None
+        self._is_running = False
+        self.run_lock = asyncio.Lock()
+        template = self.env.get_template('_daemon.ahk')
+        with open(self._template, 'w') as f:
+            f.write(template.render())
+
+    async def run(self):
+        if self._is_running:
+            raise RuntimeError("Already running")
+        self._is_running = True
+        runargs = [self.executable_path, self._template]
+        proc = await asyncio.subprocess.create_subprocess_exec(*runargs,
+                                                               stdin=asyncio.subprocess.PIPE,
+                                                               stdout=asyncio.subprocess.PIPE,
+                                                               stderr=asyncio.subprocess.PIPE)
+        self.proc = proc
+
+    async def get_command(self):
+        return await self.queue.get()
+
+    async def worker(self):
+        if not self._is_running:
+            await self.start()
+        while True:
+            command = await self.queue.get()
+            self.proc.stdin.write(command + b'\n')
+            await self.proc.stdin.drain()
+            res = await self.proc.stdout.readline()
+            self.result_queue.put_nowait(res[:-1])
+            self.queue.task_done()
+
+    def _start(self):
+        try:
+            asyncio.create_task(self.worker())
+            yield
+        finally:
+            if self.proc is not None:
+                self.proc.kill()
+
+    def stop(self):
+        if hasattr(self, '_gen') and self._gen is not None:
+            try:
+                next(self._gen)
+            except StopIteration:
+                pass
+
+    async def start(self):
+        self._gen = self._start()
+        self._gen.send(None)
+        await self.run()
+
+    def render_template(self, template_name, directives=None, blocking=True, **kwargs):
+        print(template_name)
+        name = template_name.split('/')[-1]
+        print(self._template_overrides)
+        if name in self._template_overrides:
+            template_name = f'daemon/{name}'
+        blocking = False
+        directives = None
+        kwargs['_daemon'] = True
+        return super().render_template(template_name, directives=directives, blocking=blocking, **kwargs)
+
+    async def a_run_script(self, script_text: str, decode=True, blocking=True, **runkwargs):
+        if not self._is_running:
+            raise RuntimeError("Not running! Must call .run() first!")
+        script_text = script_text.replace('#NoEnv', '', 1)
+        async with self.run_lock:
+            for line in script_text.split('\n'):
+                line = line.strip()
+                if not line:
+                    continue
+                print(line)
+                self.queue.put_nowait(line.encode('utf-8'))
+            await self.queue.join()
+            res = []
+            while not self.result_queue.empty():
+                res.append(self.result_queue.get_nowait())
+        res = b'\n'.join(i for i in res if i)
+        print(res)
+        if decode:
+            return res.decode('utf-8')
+        return res
+
+    run_script = a_run_script

--- a/ahk/daemon.py
+++ b/ahk/daemon.py
@@ -3,7 +3,8 @@ import asyncio
 from ahk.autohotkey import AsyncAHK
 
 def escape(s):
-    return s.replace('\n', '`n')
+    s = s.replace('\n', '`n')
+    return s
 
 class AHKDaemon(AsyncAHK):
     proc: asyncio.subprocess.Process
@@ -112,5 +113,9 @@ class AHKDaemon(AsyncAHK):
     async def hide_traytip(self):
         await self.run_script("HideTrayTip")
 
+    @staticmethod
+    def escape_sequence_replace(s):
+        s = escape(s)
+        return s
 
     run_script = a_run_script

--- a/ahk/daemon.py
+++ b/ahk/daemon.py
@@ -103,4 +103,14 @@ class AHKDaemon(AsyncAHK):
         s = escape(s)
         await self.send(s, *args, **kwargs)
 
+    def show_tooltip(self, text: str, second=None, x="", y="", id="", blocking=True):
+        return super().show_tooltip(text, second=second, x=x, y=y, id=id, blocking=blocking)
+
+    def hide_tooltip(self, id):
+        return super().show_tooltip(text='', second='', x='', y='', id=id)
+
+    async def hide_traytip(self):
+        await self.run_script("HideTrayTip")
+
+
     run_script = a_run_script

--- a/ahk/daemon.py
+++ b/ahk/daemon.py
@@ -72,7 +72,6 @@ class AHKDaemon(AsyncAHK):
         name = template_name.split('/')[-1]
         if name in self._template_overrides:
             template_name = f'daemon/{name}'
-        print(template_name)
         blocking = False
         directives = None
         kwargs['_daemon'] = True
@@ -85,16 +84,14 @@ class AHKDaemon(AsyncAHK):
         async with self.run_lock:
             for line in script_text.split('\n'):
                 line = line.strip()
-                if not line:
+                if not line or line.startswith("FileAppend"):
                     continue
-                print(line)
                 self.queue.put_nowait(line.encode('utf-8'))
             await self.queue.join()
             res = []
             while not self.result_queue.empty():
                 res.append(self.result_queue.get_nowait())
         res = b'\n'.join(i for i in res if i)
-        print(res)
         if decode:
             return res.decode('utf-8')
         return res

--- a/ahk/daemon.py
+++ b/ahk/daemon.py
@@ -2,6 +2,9 @@ import os
 import asyncio
 from ahk.autohotkey import AsyncAHK
 
+def escape(s):
+    return s.replace('\n', '`n')
+
 class AHKDaemon(AsyncAHK):
     proc: asyncio.subprocess.Process
     _template_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'templates')
@@ -65,11 +68,10 @@ class AHKDaemon(AsyncAHK):
         await self._run()
 
     def render_template(self, template_name, directives=None, blocking=True, **kwargs):
-        print(template_name)
         name = template_name.split('/')[-1]
-        print(self._template_overrides)
         if name in self._template_overrides:
             template_name = f'daemon/{name}'
+        print(template_name)
         blocking = False
         directives = None
         kwargs['_daemon'] = True
@@ -95,5 +97,10 @@ class AHKDaemon(AsyncAHK):
         if decode:
             return res.decode('utf-8')
         return res
+
+    async def type(self, s, *args, **kwargs):
+        kwargs['raw'] = True
+        s = escape(s)
+        await self.send(s, *args, **kwargs)
 
     run_script = a_run_script

--- a/ahk/daemon.py
+++ b/ahk/daemon.py
@@ -19,7 +19,7 @@ class AHKDaemon(AsyncAHK):
         with open(self._template, 'w') as f:
             f.write(template.render())
 
-    async def run(self):
+    async def _run(self):
         if self._is_running:
             raise RuntimeError("Already running")
         self._is_running = True
@@ -30,7 +30,7 @@ class AHKDaemon(AsyncAHK):
                                                                stderr=asyncio.subprocess.PIPE)
         self.proc = proc
 
-    async def get_command(self):
+    async def _get_command(self):
         return await self.queue.get()
 
     async def worker(self):
@@ -62,7 +62,7 @@ class AHKDaemon(AsyncAHK):
     async def start(self):
         self._gen = self._start()
         self._gen.send(None)
-        await self.run()
+        await self._run()
 
     def render_template(self, template_name, directives=None, blocking=True, **kwargs):
         print(template_name)

--- a/ahk/keyboard.py
+++ b/ahk/keyboard.py
@@ -2,7 +2,6 @@ import ast
 import warnings
 
 from ahk.script import ScriptEngine, AsyncScriptEngine
-from ahk.utils import escape_sequence_replace
 from ahk.keys import Key
 from ahk.directives import InstallKeybdHook, InstallMouseHook
 
@@ -141,7 +140,7 @@ class KeyboardMixin(ScriptEngine):
         :param s: the string to type
         :param blocking: if ``True``, waits until script finishes, else returns immediately.
         """
-        s = escape_sequence_replace(s)
+        s = self.escape_sequence_replace(s)
         return self.send_input(s, blocking=blocking) or None
 
     def _send(self, s, raw=False, delay=None, blocking=True):

--- a/ahk/screen.py
+++ b/ahk/screen.py
@@ -37,7 +37,7 @@ class ScreenMixin(ScriptEngine):
         if lower_bound:
             x2, y2 = lower_bound
         else:
-            x2, y2 = ('%A_ScreenWidth%', '%A_ScreenHeight%')
+            x2, y2 = ('A_ScreenWidth', 'A_ScreenHeight')
         script = self.render_template(
             'screen/image_search.ahk',
             x1=x1,
@@ -162,7 +162,7 @@ class ScreenMixin(ScriptEngine):
         if lower_bound:
             x2, y2 = lower_bound
         else:
-            x2, y2 = ('%A_ScreenWidth%', '%A_ScreenHeight%')
+            x2, y2 = ('A_ScreenWidth', 'A_ScreenHeight')
 
         script = self.render_template(
             'screen/pixel_search.ahk',

--- a/ahk/script.py
+++ b/ahk/script.py
@@ -15,7 +15,7 @@ import os
 import subprocess
 import warnings
 from shutil import which
-from ahk.utils import make_logger
+from ahk.utils import make_logger, escape_sequence_replace
 from ahk.directives import Persistent
 from jinja2 import Environment, FileSystemLoader
 from typing import Set
@@ -89,6 +89,10 @@ class ScriptEngine(object):
         if directives is None:
             directives = set()
         self._directives = set(directives)
+
+    @staticmethod
+    def escape_sequence_replace(*args, **kwargs):
+        return escape_sequence_replace(*args, **kwargs)
 
     def render_template(self, template_name, directives=None, blocking=True, **kwargs):
         """

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -101,6 +101,39 @@ SendInput(ByRef command) {
     SendInput,% str
 }
 
+
+SendEvent(ByRef command) {
+    command.RemoveAt(1)
+    s := Join(",", command*)
+    str := Unescape(s)
+    SendEvent,% str
+}
+
+SendPlay(ByRef command) {
+    command.RemoveAt(1)
+    s := Join(",", command*)
+    str := Unescape(s)
+    SendPlay,% str
+}
+
+SetCapsLockState(ByRef command) {
+    if (command.Length() = 1) {
+        SetCapsLockState % !GetKeyState("CapsLock", "T")
+    } else {
+        state := command[2]
+        SetCapsLockState, %state%
+    }
+}
+
+HideTrayTip(ByRef command) {
+    TrayTip ; Attempt to hide it the normal way.
+    if SubStr(A_OSVersion,1,3) = "10." {
+        Menu Tray, NoIcon
+        Sleep 200 ; It may be necessary to adjust this sleep.
+        Menu Tray, Icon
+    }
+}
+
 stdin  := FileOpen("*", "r `n")  ; Requires [v1.1.17+]
 
 Loop {

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -396,13 +396,15 @@ FromMouse(ByRef command) {
 }
 
 WinGet(ByRef command) {
-
     WinGet, output,% command[3], command[4], command[5], command[6], command[7]
     return output
 }
 
 WinSet(ByRef command) {
-    WinSet,% command[2], command[3], command[4]
+    title := command[4]
+    value := command[3]
+
+    WinSet,% command[2], %value%, %title%
 }
 
 WinSetTitle(ByRef command) {

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -43,7 +43,7 @@ CoordMode(ByRef command) {
 
 
 Click(ByRef command) {
-    if command.Length() = 1 {
+    if (command.Length() = 1) {
           Click
     } {% for i in range(2, 8) %} else if (command.Length() = {{ i }}) {
           Click{% for index in range(2, i+1) %}, command[{{index}}]{% endfor %}
@@ -52,6 +52,29 @@ Click(ByRef command) {
 
     return
 
+}
+
+MouseClickDrag(ByRef command) {
+    if (command.Length() = 6 {
+        MouseclickDrag,command[2],command[3],command[4],command[5],command[6]
+    } else if (command.Length() = 7 {
+        MouseclickDrag,command[2],command[3],command[4],command[5],command[6],command[7]
+    } else if (command.Length() = 8 {
+        MouseclickDrag,command[2],command[3],command[4],command[5],command[6],command[7],command[8]
+    }
+}
+
+RegRead(ByRef command) {
+    RegRead, output, command[3], command[4]
+    return %output%
+}
+
+SetRegView(ByRef command) {
+    SetRegView, command[2]
+}
+
+RegWrite(ByRef command) {
+    RegWrite, command[2], command[3], command[4]
 }
 
 KeyWait(ByRef command) {

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -212,7 +212,7 @@ WinGetText(ByRef command) {
 }
 
 WinActivate(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinActivate, %title%
     } else {
@@ -222,7 +222,7 @@ WinActivate(ByRef command) {
 }
 
 WinActivateBottom(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinActivateBottom, %title%
     } else {
@@ -232,9 +232,9 @@ WinActivateBottom(ByRef command) {
 }
 
 WinClose(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
-        WinClose, %title%
+        WinClose,% title
     } else {
         secondstowait = command[3]
         WinClose, %title%, %secondstowait%
@@ -242,7 +242,7 @@ WinClose(ByRef command) {
 }
 
 WinHide(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinHide, %title%
     } else {
@@ -252,7 +252,7 @@ WinHide(ByRef command) {
 }
 
 WinKill(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinKill, %title%
     } else {
@@ -262,7 +262,7 @@ WinKill(ByRef command) {
 }
 
 WinMaximize(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinMaximize, %title%
     } else {
@@ -272,7 +272,7 @@ WinMaximize(ByRef command) {
 }
 
 WinMinimize(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinMinimize, %title%
     } else {
@@ -282,7 +282,7 @@ WinMinimize(ByRef command) {
 }
 
 WinRestore(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinRestore, %title%
     } else {
@@ -292,7 +292,7 @@ WinRestore(ByRef command) {
 }
 
 WinShow(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinShow, %title%
     } else {
@@ -302,7 +302,7 @@ WinShow(ByRef command) {
 }
 
 WinWait(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinWait, %title%
     } else {
@@ -312,7 +312,7 @@ WinWait(ByRef command) {
 }
 
 WinWaitActive(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinWaitActive, %title%
     } else {
@@ -322,7 +322,7 @@ WinWaitActive(ByRef command) {
 }
 
 WinWaitNotActive(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinWaitNotActive, %title%
     } else {
@@ -332,7 +332,7 @@ WinWaitNotActive(ByRef command) {
 }
 
 WinWaitClose(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinWaitClose, %title%
     } else {
@@ -396,7 +396,11 @@ FromMouse(ByRef command) {
 }
 
 WinGet(ByRef command) {
-    WinGet, output,% command[3], command[4], command[5], command[6], command[7]
+    title := command[4]
+    text := command[5]
+    extitle := command[6]
+    extext := command[7]
+    WinGet, output,% command[3], %title%, %text%, %extitle%, %extext%
     return output
 }
 

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -1,6 +1,33 @@
 #SingleInstance Force
 #NoEnv
 
+ImageSearch(ByRef command) {
+    imagepath := command[8]
+    ImageSearch, xpos, ypos, command[4], command[5], command[6], command[7], %imagepath%
+    s .= Format("({}, {})", xpos, ypos)
+    return s
+}
+
+PixelGetColor(ByRef command) {
+    if (command.Length() = 4) {
+    PixelGetColor,color,command[3],command[4]
+    } else {
+        options := command[5]
+        PixelGetColor,color,command[3],command[4], %options%
+    }
+    return color
+}
+
+PixelSearch(ByRef command) {
+    if (command.Length() = 9) {
+        PixelSearch, xpos, ypos, command[4], command[5], command[6], command[7], command[8], command[9]
+    } else {
+        options := command[10]
+        PixelSearch, xpos, ypos, command[4], command[5], command[6], command[7], command[8], command[9], %options%
+    }
+    s .= Format("({}, {})", xpos, ypos)
+    return s
+}
 
 
 MouseGetPos(ByRef command) {
@@ -68,7 +95,7 @@ MouseClickDrag(ByRef command) {
 RegRead(ByRef command) {
     keyname := command[3]
     RegRead, output, %keyname%, command[4]
-    return %output%
+    return output
 }
 
 SetRegView(ByRef command) {

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -1,0 +1,92 @@
+#NoEnv
+
+
+
+MouseGetPos(ByRef command) {
+    MouseGetPos, xpos, ypos
+    s .= Format("({}, {})", xpos, ypos)
+    return s
+}
+
+AHKKeyState(ByRef command) {
+    if (command.Length() = 3) {
+        if (GetKeyState(command[2], command[3])) {
+            return 1
+        } else {
+            return 0
+        }
+    } else{
+        if (GetKeyState(command[2])) {
+            return 1
+        } else {
+            return 0
+        }
+    }
+}
+
+MouseMove(ByRef command) {
+    if (command.Length() = 5) {
+    MouseMove, command[2], command[3], command[4], R
+    } else {
+    MouseMove, command[2], command[3], command[4]
+    }
+}
+
+CoordMode(ByRef command) {
+    if (command.Length() = 2) {
+        CoordMode, command[2]
+    } else {
+        CoordMode, command[2], command[3]
+    }
+}
+
+
+Click(ByRef command) {
+    if command.Length() = 1 {
+          Click
+    } {% for i in range(2, 8) %} else if (command.Length() = {{ i }}) {
+          Click{% for index in range(2, i+1) %}, command[{{index}}]{% endfor %}
+
+    }{% endfor %}
+
+    return
+
+}
+
+KeyWait(ByRef command) {
+    if (command.Length() = 2) {
+        KeyWait, command[2]
+    } else {
+        KeyWait, command[2], command[3]
+    }
+    return %ErrorLevel%
+}
+
+SetKeyDelay(ByRef command) {
+    SetKeyDelay, command[2]
+}
+
+Join(sep, params*) {
+    for index,param in params
+        str .= param . sep
+    return SubStr(str, 1, -StrLen(sep))
+}
+
+Send(ByRef command) {
+    Send % Join(",", command*)
+}
+
+SendRaw(ByRef command) {
+    SendRaw % Join("," command*)
+}
+
+stdin  := FileOpen("*", "r `n")  ; Requires [v1.1.17+]
+
+Loop {
+        query := RTrim(stdin.ReadLine(), "`n")
+        commandArray := StrSplit(query, ",")
+        func := commandArray[1]
+        response := %func%(commandArray)
+        FileAppend, %response%`n, *
+}
+

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -1,29 +1,50 @@
-#SingleInstance Force
 #NoEnv
 
 ImageSearch(ByRef command) {
     imagepath := command[8]
-    ImageSearch, xpos, ypos, command[4], command[5], command[6], command[7], %imagepath%
+    x1 := command[4]
+    y1 := command[5]
+    x2 := command[6]
+    y2 := command[7]
+    if (x2 = "A_ScreenWidth") {
+        x2 := A_ScreenWidth
+    }
+    if (y2 = "A_ScreenHeight") {
+        y2 := A_ScreenHeight
+    }
+    ImageSearch, xpos, ypos,% x1,% y1,% x2,% y2, %imagepath%
     s .= Format("({}, {})", xpos, ypos)
     return s
 }
 
 PixelGetColor(ByRef command) {
+    x := command[3]
+    y := command[4]
     if (command.Length() = 4) {
-    PixelGetColor,color,command[3],command[4]
+    PixelGetColor,color,% x,% y
     } else {
         options := command[5]
-        PixelGetColor,color,command[3],command[4], %options%
+        PixelGetColor,color,% x,% y, %options%
     }
     return color
 }
 
 PixelSearch(ByRef command) {
+    x1 := command[4]
+    y1 := command[5]
+    x2 := command[6]
+    y2 := command[7]
+    if (x2 = "A_ScreenWidth") {
+        x2 := A_ScreenWidth
+    }
+    if (y2 = "A_ScreenHeight") {
+        y2 := A_ScreenHeight
+    }
     if (command.Length() = 9) {
-        PixelSearch, xpos, ypos, command[4], command[5], command[6], command[7], command[8], command[9]
+        PixelSearch, xpos, ypos,% x1,% y1,% x2,% y2, command[8], command[9]
     } else {
         options := command[10]
-        PixelSearch, xpos, ypos, command[4], command[5], command[6], command[7], command[8], command[9], %options%
+        PixelSearch, xpos, ypos,% x1,% y1,% x2,% y2, command[8], command[9], %options%
     }
     s .= Format("({}, {})", xpos, ypos)
     return s

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -195,6 +195,274 @@ HideTrayTip(ByRef command) {
     }
 }
 
+WinGetTitle(ByRef command) {
+    title := command[3]
+    WinGetTitle, text, %title%
+    return text
+}
+WinGetClass(ByRef command) {
+    title := command[3]
+    WinGetClass, text, %title%
+    return text
+}
+WinGetText(ByRef command) {
+    title := command[3]
+    WinGetText, text, %title%
+    return text
+}
+
+WinActivate(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinActivate, %title%
+    } else {
+        secondstowait = command[3]
+        WinActivate, %title%, %secondstowait%
+    }
+}
+
+WinActivateBottom(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinActivateBottom, %title%
+    } else {
+        secondstowait = command[3]
+        WinActivateBottom, %title%, %secondstowait%
+    }
+}
+
+WinClose(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinClose, %title%
+    } else {
+        secondstowait = command[3]
+        WinClose, %title%, %secondstowait%
+    }
+}
+
+WinHide(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinHide, %title%
+    } else {
+        secondstowait = command[3]
+        WinHide, %title%, %secondstowait%
+    }
+}
+
+WinKill(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinKill, %title%
+    } else {
+        secondstowait = command[3]
+        WinKill, %title%, %secondstowait%
+    }
+}
+
+WinMaximize(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinMaximize, %title%
+    } else {
+        secondstowait = command[3]
+        WinMaximize, %title%, %secondstowait%
+    }
+}
+
+WinMinimize(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinMinimize, %title%
+    } else {
+        secondstowait = command[3]
+        WinMinimize, %title%, %secondstowait%
+    }
+}
+
+WinRestore(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinRestore, %title%
+    } else {
+        secondstowait = command[3]
+        WinRestore, %title%, %secondstowait%
+    }
+}
+
+WinShow(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinShow, %title%
+    } else {
+        secondstowait = command[3]
+        WinShow, %title%, %secondstowait%
+    }
+}
+
+WinWait(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinWait, %title%
+    } else {
+        secondstowait = command[3]
+        WinWait, %title%, %secondstowait%
+    }
+}
+
+WinWaitActive(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinWaitActive, %title%
+    } else {
+        secondstowait = command[3]
+        WinWaitActive, %title%, %secondstowait%
+    }
+}
+
+WinWaitNotActive(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinWaitNotActive, %title%
+    } else {
+        secondstowait = command[3]
+        WinWaitNotActive, %title%, %secondstowait%
+    }
+}
+
+WinWaitClose(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinWaitClose, %title%
+    } else {
+        secondstowait = command[3]
+        WinWaitClose, %title%, %secondstowait%
+    }
+}
+
+
+WindowList(ByRef command) {
+    WinGet windows, List
+    Loop %windows%
+    {
+        id := windows%A_Index%
+        r .= id . "`,"
+    }
+    return r
+}
+
+WinSend(ByRef command) {
+    title := command[2]
+    command.RemoveAt(1)
+    command.RemoveAt(1)
+    str := Join(",", command*)
+    keys := Unescape(str)
+    ControlSendRaw,,% keys, %title%
+}
+
+ControlSend(ByRef command) {
+    ctrl := command[2]
+    title := command[3]
+    text := command[4]
+    extitle := command[5]
+    extext := command[6]
+    command.RemoveAt(1)
+    command.RemoveAt(1)
+    command.RemoveAt(1)
+    command.RemoveAt(1)
+    command.RemoveAt(1)
+    command.RemoveAt(1)
+    str := Join(",", command*)
+    keys := Unescape(str)
+    ControlSend, %ctrl%,% keys, %title%, %text%, %extitle%, %extext%
+}
+
+
+BaseCheck(ByRef command) {
+    kommand := command[2]
+    title := command[3]
+    if %kommand%(title) {
+        return 1
+    }
+    else {
+        return 0
+    }
+}
+
+FromMouse(ByRef command) {
+    MouseGetPos,,, MouseWin
+    return MouseWin
+}
+
+WinGet(ByRef command) {
+
+    WinGet, output,% command[3], command[4], command[5], command[6], command[7]
+    return output
+}
+
+WinSet(ByRef command) {
+    WinSet,% command[2], command[3], command[4]
+}
+
+WinIsAlwaysOnTop(ByRef command) {
+    WinGet, ExStyle, ExStyle, {{ title }}
+    if (ExStyle & 0x8)  ; 0x8 is WS_EX_TOPMOST.
+        return 1
+    else
+        return 0
+}
+
+WinClick(ByRef command) {
+    x := command[2]
+    y := command[3]
+    hwnd := command[4]
+    button := command[5]
+    n := command[6]
+    if (command.Length() = 6) {
+        ControlClick,x%x% y%y%,%hwnd%,,%button%,%n%
+    } else {
+        options := command[6]
+        ControlClick, x%x% y%y%, %hwnd%,,%button%, %n%, options
+    }
+}
+
+AHKWinMove(ByRef command) {
+    title := command [2]
+    x := command[3]
+    y := command[4]
+    if (command.Length()) = 4 {
+        WinMove,%title%,,%x%,%y%
+    } else if (command.Length() = 5) {
+        a := command[5]
+        WinMove,%title%,,%x%,%y%,%a%
+    } else if (command.Length() = 6) {
+        a := command[5]
+        b := command[6]
+        WinMove,%title%,,%x%,%y%,%a%,%b%
+    }
+}
+
+AHKWinGetPos(ByRef command) {
+    title := command[2]
+    WinGetPos, x, y, width, height, %title%
+    if (command.Length() = 3) {
+        pos_info := command[3]
+        if (pos_info = "position") {
+            s .= Format("({}, {})", x, y)
+        } else if (pos_info = "height") {
+            s .= Format("({})", height)
+        } else if (pos_info = "width") {
+            s .= Format("({})", width)
+        }
+    } else {
+        s .= Format("({}, {}, {}, {})", x, y, width, height)
+    }
+    return s
+}
+
+
+
 stdin  := FileOpen("*", "r `n")  ; Requires [v1.1.17+]
 
 Loop {

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -1,3 +1,4 @@
+#SingleInstance Force
 #NoEnv
 
 
@@ -56,11 +57,12 @@ Click(ByRef command) {
 KeyWait(ByRef command) {
     keyname := command[2]
     if (command.Length() = 2) {
-        KeyWait, %keyname%
+        KeyWait,% keyname
     } else {
-        KeyWait, %keyname%, command[3]
+        options := command[3]
+        KeyWait,% keyname,% options
     }
-    return %ErrorLevel%
+    return ErrorLevel
 }
 
 SetKeyDelay(ByRef command) {

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -405,6 +405,11 @@ WinSet(ByRef command) {
     WinSet,% command[2], command[3], command[4]
 }
 
+WinSetTitle(ByRef command) {
+    newtitle := command[4]
+    WinSetTitle,% command[2],, %newtitle%
+}
+
 WinIsAlwaysOnTop(ByRef command) {
     WinGet, ExStyle, ExStyle, {{ title }}
     if (ExStyle & 0x8)  ; 0x8 is WS_EX_TOPMOST.

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -55,26 +55,37 @@ Click(ByRef command) {
 }
 
 MouseClickDrag(ByRef command) {
-    if (command.Length() = 6 {
-        MouseclickDrag,command[2],command[3],command[4],command[5],command[6]
-    } else if (command.Length() = 7 {
-        MouseclickDrag,command[2],command[3],command[4],command[5],command[6],command[7]
-    } else if (command.Length() = 8 {
-        MouseclickDrag,command[2],command[3],command[4],command[5],command[6],command[7],command[8]
+    button := command[2]
+    if (command.Length() = 6) {
+        MouseClickDrag,%button%,command[3],command[4],command[5],command[6]
+    } else if (command.Length() = 7) {
+        MouseClickDrag,%button%,command[3],command[4],command[5],command[6],command[7]
+    } else if (command.Length() = 8) {
+        MouseClickDrag,%button%,command[3],command[4],command[5],command[6],command[7],R
     }
 }
 
 RegRead(ByRef command) {
-    RegRead, output, command[3], command[4]
+    keyname := command[3]
+    RegRead, output, %keyname%, command[4]
     return %output%
 }
 
 SetRegView(ByRef command) {
-    SetRegView, command[2]
+    view := command[2]
+    SetRegView, %view%
 }
 
 RegWrite(ByRef command) {
-    RegWrite, command[2], command[3], command[4]
+    valuetype := command[2]
+    keyname := command[3]
+
+    RegWrite, %valuetype%, %keyname%, command[4]
+}
+
+RegDelete(ByRef command) {
+    keyname := command[2]
+    RegDelete, %keyname%, command[3]
 }
 
 KeyWait(ByRef command) {

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -54,10 +54,11 @@ Click(ByRef command) {
 }
 
 KeyWait(ByRef command) {
+    keyname := command[2]
     if (command.Length() = 2) {
-        KeyWait, command[2]
+        KeyWait, %keyname%
     } else {
-        KeyWait, command[2], command[3]
+        KeyWait, %keyname%, command[3]
     }
     return %ErrorLevel%
 }

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -75,12 +75,30 @@ Join(sep, params*) {
     return SubStr(str, 1, -StrLen(sep))
 }
 
+Unescape(HayStack) {
+    ReplacedStr := StrReplace(Haystack, "``n" , "`n")
+    return ReplacedStr
+}
+
 Send(ByRef command) {
-    Send % Join(",", command*)
+    command.RemoveAt(1)
+    s := Join(",", command*)
+    str := Unescape(s)
+    Send,% str
 }
 
 SendRaw(ByRef command) {
-    SendRaw % Join("," command*)
+    command.RemoveAt(1)
+    s := Join(",", command*)
+    str := Unescape(s)
+    SendRaw,% str
+}
+
+SendInput(ByRef command) {
+    command.RemoveAt(1)
+    s := Join(",", command*)
+    str := Unescape(s)
+    SendInput,% str
 }
 
 stdin  := FileOpen("*", "r `n")  ; Requires [v1.1.17+]

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -405,10 +405,11 @@ WinGet(ByRef command) {
 }
 
 WinSet(ByRef command) {
+    subcommand := command[2]
     title := command[4]
     value := command[3]
 
-    WinSet,% command[2], %value%, %title%
+    WinSet,%subcommand%,%value%,%title%
 }
 
 WinSetTitle(ByRef command) {
@@ -417,7 +418,8 @@ WinSetTitle(ByRef command) {
 }
 
 WinIsAlwaysOnTop(ByRef command) {
-    WinGet, ExStyle, ExStyle, {{ title }}
+    title := command[2]
+    WinGet, ExStyle, ExStyle, %title%
     if (ExStyle & 0x8)  ; 0x8 is WS_EX_TOPMOST.
         return 1
     else

--- a/ahk/templates/asynchotkey.ahk
+++ b/ahk/templates/asynchotkey.ahk
@@ -1,0 +1,6 @@
+{% extends "base.ahk" %}
+{% block body %}
+{{ hotkey }}::
+    FileAppend, `n, *
+    return
+{% endblock body %}

--- a/ahk/templates/base.ahk
+++ b/ahk/templates/base.ahk
@@ -10,5 +10,5 @@
 {% endblock body %}
 
 {% block exit %}
-ExitApp
+{% if not _daemon %}ExitApp{% endif %}
 {% endblock exit %}

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -1,3 +1,4 @@
+#SingleInstance Force
 #NoEnv
 
 
@@ -64,11 +65,12 @@ Click(ByRef command) {
 KeyWait(ByRef command) {
     keyname := command[2]
     if (command.Length() = 2) {
-        KeyWait, %keyname%
+        KeyWait,% keyname
     } else {
-        KeyWait, %keyname%, command[3]
+        options := command[3]
+        KeyWait,% keyname,% options
     }
-    return %ErrorLevel%
+    return ErrorLevel
 }
 
 SetKeyDelay(ByRef command) {

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -109,6 +109,39 @@ SendInput(ByRef command) {
     SendInput,% str
 }
 
+
+SendEvent(ByRef command) {
+    command.RemoveAt(1)
+    s := Join(",", command*)
+    str := Unescape(s)
+    SendEvent,% str
+}
+
+SendPlay(ByRef command) {
+    command.RemoveAt(1)
+    s := Join(",", command*)
+    str := Unescape(s)
+    SendPlay,% str
+}
+
+SetCapsLockState(ByRef command) {
+    if (command.Length() = 1) {
+        SetCapsLockState % !GetKeyState("CapsLock", "T")
+    } else {
+        state := command[2]
+        SetCapsLockState, %state%
+    }
+}
+
+HideTrayTip(ByRef command) {
+    TrayTip ; Attempt to hide it the normal way.
+    if SubStr(A_OSVersion,1,3) = "10." {
+        Menu Tray, NoIcon
+        Sleep 200 ; It may be necessary to adjust this sleep.
+        Menu Tray, Icon
+    }
+}
+
 stdin  := FileOpen("*", "r `n")  ; Requires [v1.1.17+]
 
 Loop {

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -43,7 +43,7 @@ CoordMode(ByRef command) {
 
 
 Click(ByRef command) {
-    if command.Length() = 1 {
+    if (command.Length() = 1) {
           Click
     }  else if (command.Length() = 2) {
           Click, command[2]
@@ -60,6 +60,40 @@ Click(ByRef command) {
     }
     return
 
+}
+
+MouseClickDrag(ByRef command) {
+    button := command[2]
+    if (command.Length() = 6) {
+        MouseClickDrag,%button%,command[3],command[4],command[5],command[6]
+    } else if (command.Length() = 7) {
+        MouseClickDrag,%button%,command[3],command[4],command[5],command[6],command[7]
+    } else if (command.Length() = 8) {
+        MouseClickDrag,%button%,command[3],command[4],command[5],command[6],command[7],R
+    }
+}
+
+RegRead(ByRef command) {
+    keyname := command[3]
+    RegRead, output, %keyname%, command[4]
+    return %output%
+}
+
+SetRegView(ByRef command) {
+    view := command[2]
+    SetRegView, %view%
+}
+
+RegWrite(ByRef command) {
+    valuetype := command[2]
+    keyname := command[3]
+
+    RegWrite, %valuetype%, %keyname%, command[4]
+}
+
+RegDelete(ByRef command) {
+    keyname := command[2]
+    RegDelete, %keyname%, command[3]
 }
 
 KeyWait(ByRef command) {

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -203,6 +203,274 @@ HideTrayTip(ByRef command) {
     }
 }
 
+WinGetTitle(ByRef command) {
+    title := command[3]
+    WinGetTitle, text, %title%
+    return text
+}
+WinGetClass(ByRef command) {
+    title := command[3]
+    WinGetClass, text, %title%
+    return text
+}
+WinGetText(ByRef command) {
+    title := command[3]
+    WinGetText, text, %title%
+    return text
+}
+
+WinActivate(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinActivate, %title%
+    } else {
+        secondstowait = command[3]
+        WinActivate, %title%, %secondstowait%
+    }
+}
+
+WinActivateBottom(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinActivateBottom, %title%
+    } else {
+        secondstowait = command[3]
+        WinActivateBottom, %title%, %secondstowait%
+    }
+}
+
+WinClose(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinClose, %title%
+    } else {
+        secondstowait = command[3]
+        WinClose, %title%, %secondstowait%
+    }
+}
+
+WinHide(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinHide, %title%
+    } else {
+        secondstowait = command[3]
+        WinHide, %title%, %secondstowait%
+    }
+}
+
+WinKill(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinKill, %title%
+    } else {
+        secondstowait = command[3]
+        WinKill, %title%, %secondstowait%
+    }
+}
+
+WinMaximize(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinMaximize, %title%
+    } else {
+        secondstowait = command[3]
+        WinMaximize, %title%, %secondstowait%
+    }
+}
+
+WinMinimize(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinMinimize, %title%
+    } else {
+        secondstowait = command[3]
+        WinMinimize, %title%, %secondstowait%
+    }
+}
+
+WinRestore(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinRestore, %title%
+    } else {
+        secondstowait = command[3]
+        WinRestore, %title%, %secondstowait%
+    }
+}
+
+WinShow(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinShow, %title%
+    } else {
+        secondstowait = command[3]
+        WinShow, %title%, %secondstowait%
+    }
+}
+
+WinWait(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinWait, %title%
+    } else {
+        secondstowait = command[3]
+        WinWait, %title%, %secondstowait%
+    }
+}
+
+WinWaitActive(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinWaitActive, %title%
+    } else {
+        secondstowait = command[3]
+        WinWaitActive, %title%, %secondstowait%
+    }
+}
+
+WinWaitNotActive(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinWaitNotActive, %title%
+    } else {
+        secondstowait = command[3]
+        WinWaitNotActive, %title%, %secondstowait%
+    }
+}
+
+WinWaitClose(ByRef command) {
+    title = command[2]
+    if (command.Length() = 2) {
+        WinWaitClose, %title%
+    } else {
+        secondstowait = command[3]
+        WinWaitClose, %title%, %secondstowait%
+    }
+}
+
+
+WindowList(ByRef command) {
+    WinGet windows, List
+    Loop %windows%
+    {
+        id := windows%A_Index%
+        r .= id . "`,"
+    }
+    return r
+}
+
+WinSend(ByRef command) {
+    title := command[2]
+    command.RemoveAt(1)
+    command.RemoveAt(1)
+    str := Join(",", command*)
+    keys := Unescape(str)
+    ControlSendRaw,,% keys, %title%
+}
+
+ControlSend(ByRef command) {
+    ctrl := command[2]
+    title := command[3]
+    text := command[4]
+    extitle := command[5]
+    extext := command[6]
+    command.RemoveAt(1)
+    command.RemoveAt(1)
+    command.RemoveAt(1)
+    command.RemoveAt(1)
+    command.RemoveAt(1)
+    command.RemoveAt(1)
+    str := Join(",", command*)
+    keys := Unescape(str)
+    ControlSend, %ctrl%,% keys, %title%, %text%, %extitle%, %extext%
+}
+
+
+BaseCheck(ByRef command) {
+    kommand := command[2]
+    title := command[3]
+    if %kommand%(title) {
+        return 1
+    }
+    else {
+        return 0
+    }
+}
+
+FromMouse(ByRef command) {
+    MouseGetPos,,, MouseWin
+    return MouseWin
+}
+
+WinGet(ByRef command) {
+
+    WinGet, output,% command[3], command[4], command[5], command[6], command[7]
+    return output
+}
+
+WinSet(ByRef command) {
+    WinSet,% command[2], command[3], command[4]
+}
+
+WinIsAlwaysOnTop(ByRef command) {
+    WinGet, ExStyle, ExStyle, 
+    if (ExStyle & 0x8)  ; 0x8 is WS_EX_TOPMOST.
+        return 1
+    else
+        return 0
+}
+
+WinClick(ByRef command) {
+    x := command[2]
+    y := command[3]
+    hwnd := command[4]
+    button := command[5]
+    n := command[6]
+    if (command.Length() = 6) {
+        ControlClick,x%x% y%y%,%hwnd%,,%button%,%n%
+    } else {
+        options := command[6]
+        ControlClick, x%x% y%y%, %hwnd%,,%button%, %n%, options
+    }
+}
+
+AHKWinMove(ByRef command) {
+    title := command [2]
+    x := command[3]
+    y := command[4]
+    if (command.Length()) = 4 {
+        WinMove,%title%,,%x%,%y%
+    } else if (command.Length() = 5) {
+        a := command[5]
+        WinMove,%title%,,%x%,%y%,%a%
+    } else if (command.Length() = 6) {
+        a := command[5]
+        b := command[6]
+        WinMove,%title%,,%x%,%y%,%a%,%b%
+    }
+}
+
+AHKWinGetPos(ByRef command) {
+    title := command[2]
+    WinGetPos, x, y, width, height, %title%
+    if (command.Length() = 3) {
+        pos_info := command[3]
+        if (pos_info = "position") {
+            s .= Format("({}, {})", x, y)
+        } else if (pos_info = "height") {
+            s .= Format("({})", height)
+        } else if (pos_info = "width") {
+            s .= Format("({})", width)
+        }
+    } else {
+        s .= Format("({}, {}, {}, {})", x, y, width, height)
+    }
+    return s
+}
+
+
+
 stdin  := FileOpen("*", "r `n")  ; Requires [v1.1.17+]
 
 Loop {

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -220,7 +220,7 @@ WinGetText(ByRef command) {
 }
 
 WinActivate(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinActivate, %title%
     } else {
@@ -230,7 +230,7 @@ WinActivate(ByRef command) {
 }
 
 WinActivateBottom(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinActivateBottom, %title%
     } else {
@@ -240,9 +240,9 @@ WinActivateBottom(ByRef command) {
 }
 
 WinClose(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
-        WinClose, %title%
+        WinClose,% title
     } else {
         secondstowait = command[3]
         WinClose, %title%, %secondstowait%
@@ -250,7 +250,7 @@ WinClose(ByRef command) {
 }
 
 WinHide(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinHide, %title%
     } else {
@@ -260,7 +260,7 @@ WinHide(ByRef command) {
 }
 
 WinKill(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinKill, %title%
     } else {
@@ -270,7 +270,7 @@ WinKill(ByRef command) {
 }
 
 WinMaximize(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinMaximize, %title%
     } else {
@@ -280,7 +280,7 @@ WinMaximize(ByRef command) {
 }
 
 WinMinimize(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinMinimize, %title%
     } else {
@@ -290,7 +290,7 @@ WinMinimize(ByRef command) {
 }
 
 WinRestore(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinRestore, %title%
     } else {
@@ -300,7 +300,7 @@ WinRestore(ByRef command) {
 }
 
 WinShow(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinShow, %title%
     } else {
@@ -310,7 +310,7 @@ WinShow(ByRef command) {
 }
 
 WinWait(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinWait, %title%
     } else {
@@ -320,7 +320,7 @@ WinWait(ByRef command) {
 }
 
 WinWaitActive(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinWaitActive, %title%
     } else {
@@ -330,7 +330,7 @@ WinWaitActive(ByRef command) {
 }
 
 WinWaitNotActive(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinWaitNotActive, %title%
     } else {
@@ -340,7 +340,7 @@ WinWaitNotActive(ByRef command) {
 }
 
 WinWaitClose(ByRef command) {
-    title = command[2]
+    title := command[2]
     if (command.Length() = 2) {
         WinWaitClose, %title%
     } else {
@@ -404,13 +404,19 @@ FromMouse(ByRef command) {
 }
 
 WinGet(ByRef command) {
-
-    WinGet, output,% command[3], command[4], command[5], command[6], command[7]
+    title := command[4]
+    text := command[5]
+    extitle := command[6]
+    extext := command[7]
+    WinGet, output,% command[3], %title%, %text%, %extitle%, %extext%
     return output
 }
 
 WinSet(ByRef command) {
-    WinSet,% command[2], command[3], command[4]
+    title := command[4]
+    value := command[3]
+
+    WinSet,% command[2], %value%, %title%
 }
 
 WinSetTitle(ByRef command) {

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -1,29 +1,50 @@
-#SingleInstance Force
 #NoEnv
 
 ImageSearch(ByRef command) {
     imagepath := command[8]
-    ImageSearch, xpos, ypos, command[4], command[5], command[6], command[7], %imagepath%
+    x1 := command[4]
+    y1 := command[5]
+    x2 := command[6]
+    y2 := command[7]
+    if (x2 = "A_ScreenWidth") {
+        x2 := A_ScreenWidth
+    }
+    if (y2 = "A_ScreenHeight") {
+        y2 := A_ScreenHeight
+    }
+    ImageSearch, xpos, ypos,% x1,% y1,% x2,% y2, %imagepath%
     s .= Format("({}, {})", xpos, ypos)
     return s
 }
 
 PixelGetColor(ByRef command) {
+    x := command[3]
+    y := command[4]
     if (command.Length() = 4) {
-    PixelGetColor,color,command[3],command[4]
+    PixelGetColor,color,% x,% y
     } else {
         options := command[5]
-        PixelGetColor,color,command[3],command[4], %options%
+        PixelGetColor,color,% x,% y, %options%
     }
     return color
 }
 
 PixelSearch(ByRef command) {
+    x1 := command[4]
+    y1 := command[5]
+    x2 := command[6]
+    y2 := command[7]
+    if (x2 = "A_ScreenWidth") {
+        x2 := A_ScreenWidth
+    }
+    if (y2 = "A_ScreenHeight") {
+        y2 := A_ScreenHeight
+    }
     if (command.Length() = 9) {
-        PixelSearch, xpos, ypos, command[4], command[5], command[6], command[7], command[8], command[9]
+        PixelSearch, xpos, ypos,% x1,% y1,% x2,% y2, command[8], command[9]
     } else {
         options := command[10]
-        PixelSearch, xpos, ypos, command[4], command[5], command[6], command[7], command[8], command[9], %options%
+        PixelSearch, xpos, ypos,% x1,% y1,% x2,% y2, command[8], command[9], %options%
     }
     s .= Format("({}, {})", xpos, ypos)
     return s

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -413,6 +413,11 @@ WinSet(ByRef command) {
     WinSet,% command[2], command[3], command[4]
 }
 
+WinSetTitle(ByRef command) {
+    newtitle := command[4]
+    WinSetTitle,% command[2],, %newtitle%
+}
+
 WinIsAlwaysOnTop(ByRef command) {
     WinGet, ExStyle, ExStyle, 
     if (ExStyle & 0x8)  ; 0x8 is WS_EX_TOPMOST.

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -1,6 +1,33 @@
 #SingleInstance Force
 #NoEnv
 
+ImageSearch(ByRef command) {
+    imagepath := command[8]
+    ImageSearch, xpos, ypos, command[4], command[5], command[6], command[7], %imagepath%
+    s .= Format("({}, {})", xpos, ypos)
+    return s
+}
+
+PixelGetColor(ByRef command) {
+    if (command.Length() = 4) {
+    PixelGetColor,color,command[3],command[4]
+    } else {
+        options := command[5]
+        PixelGetColor,color,command[3],command[4], %options%
+    }
+    return color
+}
+
+PixelSearch(ByRef command) {
+    if (command.Length() = 9) {
+        PixelSearch, xpos, ypos, command[4], command[5], command[6], command[7], command[8], command[9]
+    } else {
+        options := command[10]
+        PixelSearch, xpos, ypos, command[4], command[5], command[6], command[7], command[8], command[9], %options%
+    }
+    s .= Format("({}, {})", xpos, ypos)
+    return s
+}
 
 
 MouseGetPos(ByRef command) {
@@ -76,7 +103,7 @@ MouseClickDrag(ByRef command) {
 RegRead(ByRef command) {
     keyname := command[3]
     RegRead, output, %keyname%, command[4]
-    return %output%
+    return output
 }
 
 SetRegView(ByRef command) {

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -61,7 +61,33 @@ Click(ByRef command) {
 
 }
 
+KeyWait(ByRef command) {
+    keyname := command[2]
+    if (command.Length() = 2) {
+        KeyWait, %keyname%
+    } else {
+        KeyWait, %keyname%, command[3]
+    }
+    return %ErrorLevel%
+}
 
+SetKeyDelay(ByRef command) {
+    SetKeyDelay, command[2]
+}
+
+Join(sep, params*) {
+    for index,param in params
+        str .= param . sep
+    return SubStr(str, 1, -StrLen(sep))
+}
+
+Send(ByRef command) {
+    Send % Join(",", command*)
+}
+
+SendRaw(ByRef command) {
+    SendRaw % Join("," command*)
+}
 
 stdin  := FileOpen("*", "r `n")  ; Requires [v1.1.17+]
 

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -83,12 +83,30 @@ Join(sep, params*) {
     return SubStr(str, 1, -StrLen(sep))
 }
 
+Unescape(HayStack) {
+    ReplacedStr := StrReplace(Haystack, "``n" , "`n")
+    return ReplacedStr
+}
+
 Send(ByRef command) {
-    Send % Join(",", command*)
+    command.RemoveAt(1)
+    s := Join(",", command*)
+    str := Unescape(s)
+    Send,% str
 }
 
 SendRaw(ByRef command) {
-    SendRaw % Join("," command*)
+    command.RemoveAt(1)
+    s := Join(",", command*)
+    str := Unescape(s)
+    SendRaw,% str
+}
+
+SendInput(ByRef command) {
+    command.RemoveAt(1)
+    s := Join(",", command*)
+    str := Unescape(s)
+    SendInput,% str
 }
 
 stdin  := FileOpen("*", "r `n")  ; Requires [v1.1.17+]

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -413,10 +413,11 @@ WinGet(ByRef command) {
 }
 
 WinSet(ByRef command) {
+    subcommand := command[2]
     title := command[4]
     value := command[3]
 
-    WinSet,% command[2], %value%, %title%
+    WinSet,%subcommand%,%value%,%title%
 }
 
 WinSetTitle(ByRef command) {
@@ -425,7 +426,8 @@ WinSetTitle(ByRef command) {
 }
 
 WinIsAlwaysOnTop(ByRef command) {
-    WinGet, ExStyle, ExStyle, 
+    title := command[2]
+    WinGet, ExStyle, ExStyle, %title%
     if (ExStyle & 0x8)  ; 0x8 is WS_EX_TOPMOST.
         return 1
     else

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -1,0 +1,74 @@
+#NoEnv
+
+
+
+MouseGetPos(ByRef command) {
+    MouseGetPos, xpos, ypos
+    s .= Format("({}, {})", xpos, ypos)
+    return s
+}
+
+AHKKeyState(ByRef command) {
+    if (command.Length() = 3) {
+        if (GetKeyState(command[2], command[3])) {
+            return 1
+        } else {
+            return 0
+        }
+    } else{
+        if (GetKeyState(command[2])) {
+            return 1
+        } else {
+            return 0
+        }
+    }
+}
+
+MouseMove(ByRef command) {
+    if (command.Length() = 5) {
+    MouseMove, command[2], command[3], command[4], R
+    } else {
+    MouseMove, command[2], command[3], command[4]
+    }
+}
+
+CoordMode(ByRef command) {
+    if (command.Length() = 2) {
+        CoordMode, command[2]
+    } else {
+        CoordMode, command[2], command[3]
+    }
+}
+
+
+Click(ByRef command) {
+    if command.Length() = 1 {
+          Click
+    }  else if (command.Length() = 2) {
+          Click, command[2]
+    } else if (command.Length() = 3) {
+          Click, command[2], command[3]
+    } else if (command.Length() = 4) {
+          Click, command[2], command[3], command[4]
+    } else if (command.Length() = 5) {
+          Click, command[2], command[3], command[4], command[5]
+    } else if (command.Length() = 6) {
+          Click, command[2], command[3], command[4], command[5], command[6]
+    } else if (command.Length() = 7) {
+          Click, command[2], command[3], command[4], command[5], command[6], command[7]
+    }
+    return
+
+}
+
+
+
+stdin  := FileOpen("*", "r `n")  ; Requires [v1.1.17+]
+
+Loop {
+        query := RTrim(stdin.ReadLine(), "`n")
+        commandArray := StrSplit(query, ",")
+        func := commandArray[1]
+        response := %func%(commandArray)
+        FileAppend, %response%`n, *
+}

--- a/ahk/templates/daemon/base_check.ahk
+++ b/ahk/templates/daemon/base_check.ahk
@@ -1,0 +1,1 @@
+BaseCheck,{{ command }},{{ title }}

--- a/ahk/templates/daemon/control_send.ahk
+++ b/ahk/templates/daemon/control_send.ahk
@@ -1,0 +1,1 @@
+ControlSend,{{ control }},{{ win_title }},{{ win_text }},{{ exclude_title }},{{ exclude_text }},{{keys}}

--- a/ahk/templates/daemon/from_mouse.ahk
+++ b/ahk/templates/daemon/from_mouse.ahk
@@ -1,0 +1,1 @@
+FromMouse

--- a/ahk/templates/daemon/id_list.ahk
+++ b/ahk/templates/daemon/id_list.ahk
@@ -1,0 +1,1 @@
+WindowList

--- a/ahk/templates/daemon/image_search.ahk
+++ b/ahk/templates/daemon/image_search.ahk
@@ -1,0 +1,2 @@
+CoordMode, Pixel, {{ coord_mode }}
+ImageSearch, xpos, ypos, {{ x1 }}, {{ y1 }}, {{ x2 }}, {{ y2 }}, {% if options %}{% for option in options %}*{{ option }} {% endfor %}{% endif %}{{ image_path }}

--- a/ahk/templates/daemon/image_search.ahk
+++ b/ahk/templates/daemon/image_search.ahk
@@ -1,2 +1,2 @@
 CoordMode, Pixel, {{ coord_mode }}
-ImageSearch, xpos, ypos, {{ x1 }}, {{ y1 }}, {{ x2 }}, {{ y2 }}, {% if options %}{% for option in options %}*{{ option }} {% endfor %}{% endif %}{{ image_path }}
+ImageSearch,xpos,ypos,{{ x1 }},{{ y1 }},{{ x2 }},{{ y2 }},{% if options %}{% for option in options %}*{{ option }} {% endfor %}{% endif %}{{ image_path }}

--- a/ahk/templates/daemon/key_state.ahk
+++ b/ahk/templates/daemon/key_state.ahk
@@ -1,0 +1,1 @@
+AHKKeyState, {{ key_name }}{% if mode %}, {{ mode }}{% endif %}

--- a/ahk/templates/daemon/key_wait.ahk
+++ b/ahk/templates/daemon/key_wait.ahk
@@ -1,0 +1,1 @@
+KeyWait,{{ key_name }}{% if options %},{{ options }}{% endif %}

--- a/ahk/templates/daemon/pixel_get_color.ahk
+++ b/ahk/templates/daemon/pixel_get_color.ahk
@@ -1,0 +1,2 @@
+CoordMode, Pixel, {{ coord_mode }}
+PixelGetColor,color,{{ x }},{{ y }}{% if options %},{% for option in options %} {{ option }}{% endfor %}{% endif %}

--- a/ahk/templates/daemon/pixel_search.ahk
+++ b/ahk/templates/daemon/pixel_search.ahk
@@ -1,0 +1,2 @@
+CoordMode, Pixel, {{ coord_mode }}
+PixelSearch, xpos, ypos,{{ x1 }},{{ y1 }},{{ x2 }},{{ y2 }},{{ color }},{{ variation }}{% if options %},{% for option in options %} {{ option }}{% endfor %}{% endif %}

--- a/ahk/templates/daemon/set_capslock_state.ahk
+++ b/ahk/templates/daemon/set_capslock_state.ahk
@@ -1,0 +1,1 @@
+{% if state %}SetCapsLockState,{{state}}{% else %}SetCapsLockState{% endif %}

--- a/ahk/templates/daemon/tooltip.ahk
+++ b/ahk/templates/daemon/tooltip.ahk
@@ -1,0 +1,1 @@
+ToolTip, {{ text }}, {{ x }}, {{ y }}, {{ id }}

--- a/ahk/templates/daemon/traytip.ahk
+++ b/ahk/templates/daemon/traytip.ahk
@@ -1,0 +1,1 @@
+TrayTip {{ title }}, {{ text }}, {{ second }}, {{ option }}

--- a/ahk/templates/daemon/win_click.ahk
+++ b/ahk/templates/daemon/win_click.ahk
@@ -1,0 +1,1 @@
+WinClick,{{ x }},{{ y }},{{ hwnd }},{{ button }},{{ n }}{% if options %},{{ options }}{% endif %}

--- a/ahk/templates/daemon/win_is_always_on_top.ahk
+++ b/ahk/templates/daemon/win_is_always_on_top.ahk
@@ -1,1 +1,1 @@
-WinIsAlwaysOnTop
+WinIsAlwaysOnTop,{{ title }}

--- a/ahk/templates/daemon/win_is_always_on_top.ahk
+++ b/ahk/templates/daemon/win_is_always_on_top.ahk
@@ -1,0 +1,1 @@
+WinIsAlwaysOnTop

--- a/ahk/templates/daemon/win_move.ahk
+++ b/ahk/templates/daemon/win_move.ahk
@@ -1,0 +1,1 @@
+AHKWinMove,{{ title }},{{ x }},{{ y }}{% if width %},{{ width }}{% endif %}{% if height %},{{ height }}{% endif %}

--- a/ahk/templates/daemon/win_position.ahk
+++ b/ahk/templates/daemon/win_position.ahk
@@ -1,0 +1,5 @@
+{% if pos_info %}
+AHKWinGetPos,{{ title }},{{ pos_info }}
+{% else %}
+AHKWinGetPos,{{ title }}
+{% endif %}

--- a/ahk/templates/daemon/win_send.ahk
+++ b/ahk/templates/daemon/win_send.ahk
@@ -1,0 +1,2 @@
+SetKeyDelay,{{ delay }},{{ press_duration }}
+WinSend,{{ title }},{{ keys }}

--- a/ahk/templates/keyboard/send.ahk
+++ b/ahk/templates/keyboard/send.ahk
@@ -2,5 +2,5 @@
 {% block body %}
 {% if delay %}SetKeyDelay, {{ delay }}{% endif %}
 
-Send{% if raw %}Raw{% endif %}, {{ s }}
+Send{% if raw %}Raw{% endif %},{{ s }}
 {% endblock body %}

--- a/ahk/templates/keyboard/send_event.ahk
+++ b/ahk/templates/keyboard/send_event.ahk
@@ -2,5 +2,5 @@
 {% block body %}
 {% if delay %}SetKeyDelay, {{ delay }}{% endif %}
 
-SendEvent {{ s }}
+SendEvent,{{ s }}
 {% endblock body %}

--- a/ahk/templates/keyboard/send_input.ahk
+++ b/ahk/templates/keyboard/send_input.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
 
-SendInput {{ s }}
+SendInput,{{ s }}
 {% endblock body %}

--- a/ahk/templates/keyboard/send_play.ahk
+++ b/ahk/templates/keyboard/send_play.ahk
@@ -2,5 +2,5 @@
 {% block body %}
 {% if delay %}SetKeyDelay, {{ delay }}{% endif %}
 
-SendPlay {{ s }}
+SendPlay,{{ s }}
 {% endblock body %}

--- a/ahk/templates/mouse/click.ahk
+++ b/ahk/templates/mouse/click.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
-CoordMode Mouse, {{mode}}
+CoordMode, Mouse, {{mode}}
 Click{% for arg in args %}, {{ arg }}{% endfor %}
 {% endblock %}

--- a/ahk/templates/mouse/mouse_drag.ahk
+++ b/ahk/templates/mouse/mouse_drag.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
-CoordMode Mouse, {{mode}}
-MouseClickDrag, {{button}}, {{x1}}, {{y1}}, {{x2}}, {{y2}}{% if speed %}, {{speed}}{% endif %}{% if relative %}, R{% endif %}
+CoordMode, Mouse, {{mode}}
+MouseClickDrag,{{button}},{{x1}},{{y1}},{{x2}},{{y2}}{% if speed %},{{speed}}{% endif %}{% if relative %},R{% endif %}
 {% endblock body %}

--- a/ahk/templates/mouse/mouse_move.ahk
+++ b/ahk/templates/mouse/mouse_move.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
-CoordMode Mouse, {{mode}}
+CoordMode, Mouse, {{mode}}
 MouseMove, {{x}}, {{y}}, {{speed}}{% if relative %}, R{% endif %}
 {% endblock body %}

--- a/ahk/templates/registery/reg_delete.ahk
+++ b/ahk/templates/registery/reg_delete.ahk
@@ -1,4 +1,4 @@
 {% extends "base.ahk" %}
 {% block body %}
-RegDelete, {{ key_name }}, {{ value_name }}
+RegDelete,{{ key_name }},{{ value_name }}
 {% endblock body %}

--- a/ahk/templates/registery/reg_read.ahk
+++ b/ahk/templates/registery/reg_read.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
-RegRead, output, {{ key_name }}, {{ value_name }}
+RegRead,output,{{ key_name }},{{ value_name }}
 FileAppend, %output%, *
 {% endblock body %}

--- a/ahk/templates/registery/reg_write.ahk
+++ b/ahk/templates/registery/reg_write.ahk
@@ -1,4 +1,4 @@
 {% extends "base.ahk" %}
 {% block body %}
-RegWrite, {{ value_type }}, {{ key_name }}, {{ value_name }}
+RegWrite,{{ value_type }},{{ key_name }},{{ value_name }}
 {% endblock body %}

--- a/ahk/templates/screen/image_search.ahk
+++ b/ahk/templates/screen/image_search.ahk
@@ -1,7 +1,7 @@
 {% extends "base.ahk" %}
 {% block body %}
-CoordMode Pixel, {{ coord_mode }}
-ImageSearch, xpos, ypos, {{ x1 }}, {{ y1 }}, {{ x2 }}, {{ y2 }}, {% if options %}{% for option in options %}*{{ option }} {% endfor %}{% endif %}{{ image_path }}
+CoordMode, Pixel, {{ coord_mode }}
+ImageSearch,xpos,ypos,{{ x1 }},{{ y1 }},{{ x2 }},{{ y2 }},{% if options %}{% for option in options %}*{{ option }} {% endfor %}{% endif %}{{ image_path }}
 s .= Format("({}, {})", xpos, ypos)
 FileAppend, %s%, *
 {% endblock body %}

--- a/ahk/templates/screen/pixel_get_color.ahk
+++ b/ahk/templates/screen/pixel_get_color.ahk
@@ -1,7 +1,7 @@
 {% extends "base.ahk" %}
 {% block body %}
-CoordMode Pixel, {{ coord_mode }}
-PixelGetColor, color, {{ x }}, {{ y }}{% if options %},{% for option in options %} {{ option }}{% endfor %}{% endif %}
+CoordMode, Pixel, {{ coord_mode }}
+PixelGetColor, color,{{ x }},{{ y }}{% if options %},{% for option in options %} {{ option }}{% endfor %}{% endif %}
 
 FileAppend, %color%, *
 {% endblock body %}

--- a/ahk/templates/screen/pixel_get_color.ahk
+++ b/ahk/templates/screen/pixel_get_color.ahk
@@ -1,7 +1,7 @@
 {% extends "base.ahk" %}
 {% block body %}
 CoordMode, Pixel, {{ coord_mode }}
-PixelGetColor, color,{{ x }},{{ y }}{% if options %},{% for option in options %} {{ option }}{% endfor %}{% endif %}
+PixelGetColor,color, {{ x }}, {{ y }}{% if options %},{% for option in options %} {{ option }}{% endfor %}{% endif %}
 
 FileAppend, %color%, *
 {% endblock body %}

--- a/ahk/templates/screen/pixel_search.ahk
+++ b/ahk/templates/screen/pixel_search.ahk
@@ -1,7 +1,8 @@
 {% extends "base.ahk" %}
 {% block body %}
-CoordMode Pixel, {{ coord_mode }}
+CoordMode, Pixel, {{ coord_mode }}
 PixelSearch, xpos, ypos, {{ x1 }}, {{ y1 }}, {{ x2 }}, {{ y2 }}, {{ color }} , {{ variation }}{% if options %},{% for option in options %} {{ option }}{% endfor %}{% endif %}
+
 s .= Format("({}, {})", xpos, ypos)
 FileAppend, %s%, *
 {% endblock body %}

--- a/ahk/templates/screen/pixel_search.ahk
+++ b/ahk/templates/screen/pixel_search.ahk
@@ -2,7 +2,6 @@
 {% block body %}
 CoordMode Pixel, {{ coord_mode }}
 PixelSearch, xpos, ypos, {{ x1 }}, {{ y1 }}, {{ x2 }}, {{ y2 }}, {{ color }} , {{ variation }}{% if options %},{% for option in options %} {{ option }}{% endfor %}{% endif %}
-
 s .= Format("({}, {})", xpos, ypos)
 FileAppend, %s%, *
 {% endblock body %}

--- a/ahk/templates/window/base_command.ahk
+++ b/ahk/templates/window/base_command.ahk
@@ -1,4 +1,4 @@
 {% extends "base.ahk" %}
 {% block body %}
-{{ command }}, {{ title }}{% if seconds_to_wait %}, {{ seconds_to_wait }}{% endif %}
+{{ command }},{{ title }}{% if seconds_to_wait %},{{ seconds_to_wait }}{% endif %}
 {% endblock body %}

--- a/ahk/templates/window/base_get_command.ahk
+++ b/ahk/templates/window/base_get_command.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
-{{ command }}, text, {{ title }}
+{{ command }},text,{{ title }}
 FileAppend, %text%, *
 {% endblock body %}

--- a/ahk/templates/window/control_send.ahk
+++ b/ahk/templates/window/control_send.ahk
@@ -1,4 +1,4 @@
 {% extends "base.ahk" %}
 {% block body %}
-ControlSend, {{ control }}, {{ keys }}, {{ win_title }}, {{ win_text }}, {{ exclude_title }}, {{ exclude_text }}
+ControlSend,{{ control }},{{ keys }},{{ win_title }},{{ win_text }},{{ exclude_title }},{{ exclude_text }}
 {% endblock body %}

--- a/ahk/templates/window/get.ahk
+++ b/ahk/templates/window/get.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
-WinGet, output, {{ subcommand }}, {{ title }}, {{ text }}, {{ exclude_title }}, {{ exclude_text }}
+WinGet, output,{{ subcommand }},{{ title }},{{ text }},{{ exclude_title }},{{ exclude_text }}
 FileAppend, %output%, *
 {% endblock body %}

--- a/ahk/templates/window/id_list.ahk
+++ b/ahk/templates/window/id_list.ahk
@@ -4,7 +4,7 @@ WinGet windows, List
 Loop %windows%
 {
     id := windows%A_Index%
-    r .= id . "`n"
+    r .= id . "`,"
 }
 FileAppend, %r%, *
 {% endblock body %}

--- a/ahk/templates/window/win_move.ahk
+++ b/ahk/templates/window/win_move.ahk
@@ -1,4 +1,4 @@
 {% extends "base.ahk" %}
 {% block body %}
-WinMove, {{ title }}, , {{ x }}, {{ y }}{% if width %}, {{ width }}{% endif %}{% if height %}, {{ height }}{% endif %}
+WinMove,{{ title }},,{{ x }},{{ y }}{% if width %},{{ width }}{% endif %}{% if height %},{{ height }}{% endif %}
 {% endblock body %}

--- a/ahk/templates/window/win_set.ahk
+++ b/ahk/templates/window/win_set.ahk
@@ -1,4 +1,4 @@
 {% extends "base.ahk" %}
 {% block body %}
-WinSet, {{subcommand}}, {{value}}, {{ title }}
+WinSet,{{subcommand}},{{value}},{{ title }}
 {% endblock body %}

--- a/ahk/templates/window/win_set_title.ahk
+++ b/ahk/templates/window/win_set_title.ahk
@@ -1,4 +1,4 @@
 {% extends "base.ahk" %}
 {% block body %}
-WinSetTitle, {{ title }}, {{ text }}, {{ new_title }}
+WinSetTitle,{{ title }},{{ text }},{{ new_title }}
 {% endblock body %}

--- a/ahk/window.py
+++ b/ahk/window.py
@@ -602,7 +602,7 @@ class Window(object):
         )
         return script
 
-    def send(self, keys, delay=10, raw=False, blocking=False, escape=False, press_duration=-1):
+    def send(self, keys, delay=10, raw=False, blocking=True, escape=False, press_duration=-1):
         """
         Send keystrokes directly to the window.
         Uses ControlSend

--- a/ahk/window.py
+++ b/ahk/window.py
@@ -589,11 +589,11 @@ class Window(object):
         :return: 
         """
         script = self._move(x=x, y=y, width=width, height=height)
-        self.engine.run_script(script)
+        return self.engine.run_script(script) or None
 
     def _send(self, keys, delay=10, raw=False, blocking=False, escape=False, press_duration=-1):
         if escape:
-            keys = escape_sequence_replace(keys)
+            keys = self.engine.escape_sequence_replace(keys)
         script = self._render_template(
             'window/win_send.ahk',
             title=f"ahk_id {self.id}",
@@ -701,7 +701,7 @@ class WindowMixin(ScriptEngine):
     def _all_window_ids(self):
         script = self._all_window_ids_()
         result = self.run_script(script)
-        return result.split('\n')[:-1]  # last one is always an empty string
+        return result.split(',')[:-1]  # last one is always an empty string
 
     def windows(self):
         """
@@ -971,7 +971,7 @@ class AsyncWindowMixin(AsyncScriptEngine, WindowMixin):
     async def _all_window_ids(self):
         script = self._all_window_ids_()
         result = await self.a_run_script(script)
-        return result.split('\n')[:-1]  # last one is always an empty string
+        return result.split(',')[:-1]  # last one is always an empty string
 
     async def windows(self):
         """
@@ -1043,7 +1043,7 @@ class AsyncWindowMixin(AsyncScriptEngine, WindowMixin):
         :return: a :py:class:`~ahk.window.Window` object or ``None`` if no matching window is found
         """
 
-        async for window in self.find_windows_by_title():
+        async for window in self.find_windows_by_title(title=title):
             return window
 
     async def find_windows_by_text(self, text, exact=False):

--- a/tests/unittests/test_blocking_mouse.py
+++ b/tests/unittests/test_blocking_mouse.py
@@ -18,8 +18,9 @@ def test_blocking_blocks():
 def test_nonblocking_does_not_block():
     ahk.mouse_position = (100, 100)
     assert ahk.mouse_position == (100, 100)
-    ahk.mouse_move(10, 10, speed=30, blocking=False)
+    proc = ahk.mouse_move(10, 10, speed=30, blocking=False)
     assert ahk.mouse_position != (10, 10)
     time.sleep(0.1)
     assert ahk.mouse_position != (100, 100)  # make sure it actually moved!
-
+    proc.kill()
+    time.sleep(0.1)

--- a/tests/unittests/test_daemon.py
+++ b/tests/unittests/test_daemon.py
@@ -1,12 +1,15 @@
 import asyncio
+import subprocess
 import time
 import sys
 import os
 from unittest import IsolatedAsyncioTestCase
 
+
 project_root = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../..'))
 sys.path.insert(0, project_root)
 from ahk.daemon import AHKDaemon
+from ahk.window import AsyncWindow
 
 
 class TestMouseAsync(IsolatedAsyncioTestCase):
@@ -21,3 +24,94 @@ class TestMouseAsync(IsolatedAsyncioTestCase):
         x, y = await self.ahk.mouse_position
         await self.ahk.mouse_move(10, 10, relative=True)
         assert await self.ahk.mouse_position == (x+10, y+10)
+
+
+class TestWindowAsync(IsolatedAsyncioTestCase):
+    win: AsyncWindow
+    async def asyncSetUp(self):
+        self.ahk = AHKDaemon()
+        await self.ahk.start()
+        self.p = subprocess.Popen('notepad')
+        time.sleep(1)
+        self.win = await self.ahk.win_get(title='Untitled - Notepad')
+        self.assertIsNotNone(self.win)
+
+    async def test_transparent(self):
+        self.assertEqual(await self.win.get_transparency(), 255)
+
+        await self.win.set_transparency(220)
+        self.assertEqual(await self.win.get_transparency(), 220)
+
+        self.win.transparent = 255
+        await asyncio.sleep(0.5)
+        self.assertEqual(await self.win.transparent, 255)
+
+
+    async def test_pinned(self):
+        self.assertFalse(await self.win.always_on_top)
+
+        await self.win.set_always_on_top(True)
+        self.assertTrue(await self.win.is_always_on_top())
+
+        self.win.always_on_top = False
+        await asyncio.sleep(1)
+        self.assertFalse(await self.win.always_on_top)
+
+    async def test_close(self):
+        await self.win.close()
+        await asyncio.sleep(0.2)
+        self.assertFalse(await self.win.exists())
+        self.assertFalse(await self.win.exist)
+
+    async def test_show_hide(self):
+        await self.win.hide()
+        await asyncio.sleep(0.5)
+        self.assertFalse(await self.win.exist)
+
+        await self.win.show()
+        await asyncio.sleep(0.5)
+        self.assertTrue(await self.win.exist)
+
+    async def test_kill(self):
+        await self.win.kill()
+        await asyncio.sleep(0.5)
+        self.assertFalse(await self.win.exist)
+
+    async def test_max_min(self):
+        self.assertTrue(await self.win.non_max_non_min)
+        self.assertFalse(await self.win.is_minmax())
+
+        await self.win.maximize()
+        await asyncio.sleep(1)
+        self.assertTrue(await self.win.maximized)
+        self.assertTrue(await self.win.is_maximized())
+
+        await self.win.minimize()
+        await asyncio.sleep(1)
+        self.assertTrue(await self.win.minimized)
+        self.assertTrue(await self.win.is_minimized())
+
+        await self.win.restore()
+        await asyncio.sleep(0.5)
+        self.assertTrue(await self.win.maximized)
+        self.assertTrue(await self.win.is_maximized())
+#
+    async def test_names(self):
+        self.assertEqual(await self.win.class_name, b'Notepad')
+        self.assertEqual(await self.win.get_class_name(), b'Notepad')
+
+        self.assertEqual(await self.win.title, b'Untitled - Notepad')
+        self.assertEqual(await self.win.get_title(), b'Untitled - Notepad')
+
+        self.assertEqual(await self.win.text, b'')
+        self.assertEqual(await self.win.get_text(), b'')
+
+    async def test_title_setter(self):
+        starting_title = await self.win.title
+        await self.win.set_title("new title")
+        assert await self.win.get_title() != starting_title
+
+    async def asyncTearDown(self):
+        self.ahk.stop()
+        self.p.terminate()
+        await asyncio.sleep(0.5)

--- a/tests/unittests/test_daemon.py
+++ b/tests/unittests/test_daemon.py
@@ -1,0 +1,26 @@
+import asyncio
+import time
+import sys
+import os
+from unittest import IsolatedAsyncioTestCase
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../..'))
+sys.path.insert(0, project_root)
+from ahk.daemon import AHKDaemon
+
+
+class TestMouseAsync(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.ahk = AHKDaemon()
+        await self.ahk.start()
+
+    def tearDown(self) -> None:
+        self.ahk.stop()
+
+    async def test_mouse_move(self):
+        x, y = await self.ahk.mouse_position
+        await self.ahk.mouse_move(10, 10, relative=True)
+        assert await self.ahk.mouse_position == (x+10, y+10)
+
+
+

--- a/tests/unittests/test_daemon.py
+++ b/tests/unittests/test_daemon.py
@@ -21,6 +21,3 @@ class TestMouseAsync(IsolatedAsyncioTestCase):
         x, y = await self.ahk.mouse_position
         await self.ahk.mouse_move(10, 10, relative=True)
         assert await self.ahk.mouse_position == (x+10, y+10)
-
-
-

--- a/tests/unittests/test_daemon.py
+++ b/tests/unittests/test_daemon.py
@@ -9,7 +9,7 @@ from itertools import product
 project_root = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../..'))
 sys.path.insert(0, project_root)
 from ahk.daemon import AHKDaemon
-from ahk.window import AsyncWindow
+from ahk.window import AsyncWindow, WindowNotFoundError
 from PIL import Image
 
 class TestMouseDaemon(IsolatedAsyncioTestCase):
@@ -154,3 +154,43 @@ class TestScreenDaemon(IsolatedAsyncioTestCase):
         result = await self.ahk.pixel_get_color(x, y)
         self.assertIsNotNone(result)
         self.assertEqual(int(result, 16), 0xFF0000)
+
+
+class TestWinGetDaemon(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.ahk = AHKDaemon()
+        await self.ahk.start()
+        self.p = subprocess.Popen('notepad')
+        time.sleep(1)
+        self.win = await self.ahk.win_get(title='Untitled - Notepad')
+        self.assertIsNotNone(self.win)
+
+    async def asyncTearDown(self):
+        self.p.terminate()
+        await asyncio.sleep(0.5)
+        self.ahk.stop()
+
+
+    async def test_get_calculator(self):
+        assert await self.win.position
+
+
+    async def test_win_close(self):
+        await self.win.close()
+        try:
+            win = await self.ahk.win_get(title='Untitled - Notepad')
+            await win.position
+        except WindowNotFoundError as e:
+            pass
+        else:
+            raise AssertionError("Expected WindowNotFoundError")
+
+    async def test_find_window_func(self):
+        async def func(win):
+            return b'Untitled' in await win.title
+        assert self.win == await self.ahk.find_window(func=func)
+
+    async def test_getattr_window_subcommand(self):
+        assert isinstance(await self.win.pid, str)
+
+

--- a/tests/unittests/test_keyboard_async.py
+++ b/tests/unittests/test_keyboard_async.py
@@ -16,7 +16,7 @@ from ahk import AsyncAHK, AHK
 from ahk.keys import ALT, CTRL, KEYS
 
 
-class TestKeyboardAsync(TestCase):
+class TestKeyboardAsync(IsolatedAsyncioTestCase):
     def setUp(self):
         """
         Record all open windows
@@ -28,10 +28,9 @@ class TestKeyboardAsync(TestCase):
         self.p = subprocess.Popen("notepad")
         time.sleep(1)
 
-    def tearDown(self):
+    async def asyncTearDown(self):
         self.p.terminate()
-        time.sleep(0.2)
-        asyncio.run(asyncio.sleep(0.2))
+        await asyncio.sleep(0.5)
 
     async def test_window_send(self):
         notepad = await self.ahk.find_window(title=b"Untitled - Notepad")


### PR DESCRIPTION
This PR adds a daemon mode.

Because processes are expensive to create in Windows, this can lead to performance issues for some use-cases. Daemon mode allows AHK commands to be carried out in a single process, as opposed to running each command in a new subprocess, allowing for rapid invocation of commands.

This is particularly useful for cases that need very fast response times, like for fast-paced games.

A quick demo shows the potential for increased performance:

```python
import asyncio, time
from ahk import AHK
from ahk.daemon import AHKDaemon
def normal_ahk():
    start = time.time()
    ahk = AHK()
    for _ in range(50):
        ahk.get_mouse_position()
    end = time.time()
    print(end - start)

async def daemon_mode():
    start = time.time()
    daemon = AHKDaemon()
    await daemon.start()
    for _ in range(50):
        await daemon.get_mouse_position()
    end = time.time()
    daemon.stop()
    print(end - start)

normal_ahk() # 5.151455640792847
asyncio.run(daemon_mode()) # 0.17191839218139648
```