### PR TITLE
Adds TranspileOnly directive to print resulting AHK code instead of running it

### DIFF
--- a/ahk/autohotkey.py
+++ b/ahk/autohotkey.py
@@ -22,7 +22,7 @@ class AHK(WindowMixin, MouseMixin, KeyboardMixin, ScreenMixin, SoundMixin, Regis
     | :py:class:`ahk.gui.GUIMixin`
     """
     
-    transpile_only = False
+    pass
     
 
 #

--- a/ahk/autohotkey.py
+++ b/ahk/autohotkey.py
@@ -21,8 +21,9 @@ class AHK(WindowMixin, MouseMixin, KeyboardMixin, ScreenMixin, SoundMixin, Regis
     | :py:class:`ahk.registery.RegisteryMixin`
     | :py:class:`ahk.gui.GUIMixin`
     """
-
-    pass
+    
+    transpile_only = False
+    
 
 #
 class AsyncAHK(

--- a/ahk/directives.py
+++ b/ahk/directives.py
@@ -151,6 +151,8 @@ class Persistent(Directive):
 class SingleInstance(Directive):
     pass
 
+class TranspileOnly(Directive):
+    pass
 
 class UseHook(Directive):
     pass

--- a/ahk/directives.py
+++ b/ahk/directives.py
@@ -151,8 +151,6 @@ class Persistent(Directive):
 class SingleInstance(Directive):
     pass
 
-class TranspileOnly(Directive):
-    pass
 
 class UseHook(Directive):
     pass

--- a/ahk/script.py
+++ b/ahk/script.py
@@ -117,6 +117,9 @@ class ScriptEngine(object):
             directives.remove(Persistent)
         if self._directives:
             directives.update(self._directives)
+        
+        if TranspileOnly in directives:
+            directives.remove(TranspileOnly)
 
         kwargs['directives'] = directives
         template = self.env.get_template(template_name)

--- a/ahk/script.py
+++ b/ahk/script.py
@@ -90,6 +90,8 @@ class ScriptEngine(object):
             directives = set()
         self._directives = set(directives)
 
+        self.transpile = "transpile" in kwargs and kwargs["transpile"]
+
     def render_template(self, template_name, directives=None, blocking=True, **kwargs):
         """
         Renders a given jinja template and returns a string of script text
@@ -118,9 +120,6 @@ class ScriptEngine(object):
         if self._directives:
             directives.update(self._directives)
         
-        if TranspileOnly in directives:
-            directives.remove(TranspileOnly)
-
         kwargs['directives'] = directives
         template = self.env.get_template(template_name)
         return template.render(**kwargs)
@@ -216,7 +215,7 @@ class ScriptEngine(object):
         <subprocess.Popen at 0x18a599cde10>
         """
         
-        if TranspileOnly in self._directives:
+        if self.transpile:
             print(script_text)
             return None
         

--- a/ahk/script.py
+++ b/ahk/script.py
@@ -16,7 +16,7 @@ import subprocess
 import warnings
 from shutil import which
 from ahk.utils import make_logger
-from ahk.directives import Persistent, TranspileOnly
+from ahk.directives import Persistent
 from jinja2 import Environment, FileSystemLoader
 from typing import Set
 logger = make_logger(__name__)

--- a/ahk/script.py
+++ b/ahk/script.py
@@ -16,7 +16,7 @@ import subprocess
 import warnings
 from shutil import which
 from ahk.utils import make_logger
-from ahk.directives import Persistent
+from ahk.directives import Persistent, TranspileOnly
 from jinja2 import Environment, FileSystemLoader
 from typing import Set
 logger = make_logger(__name__)
@@ -212,6 +212,12 @@ class ScriptEngine(object):
         >>> ahk.run_script('FileAppend, Hello World, *', blocking=False)
         <subprocess.Popen at 0x18a599cde10>
         """
+        
+        if TranspileOnly in self._directives:
+            print(script_text)
+            return None
+        
+		
         logger.debug('Running script text: %s', script_text)
         try:
             result = self._run_script(script_text, decode=decode, blocking=blocking, **runkwargs)


### PR DESCRIPTION
This is pretty simple, I modified a demo from the readme to get this:

```py
from ahk import AHK
from ahk.directives import TranspileOnly
ahk = AHK(directives = [TranspileOnly])

ahk.mouse_move(x=100, y=100, blocking=True)
```

This code did not execute any AHK, instead printing it to stdout:

```ahk
#NoEnv
#Persistent

CoordMode Mouse, Screen
MouseMove, 100, 100, 2
ExitApp
```

I'm unsure if you want directives like this to be mixed in with "real" AHK directives, so perhaps this is not an ideal implementation. Also if you like this idea it probably would make sense to have options to write the output to a file instead of stdout.

I look forward to hearing what you think, and thanks for the good work!