### PR TITLE
Daemon protocol to fix multiline response handling

### DIFF
--- a/ahk/daemon.py
+++ b/ahk/daemon.py
@@ -52,7 +52,8 @@ class AHKDaemon(AHK):
                 break
             self.proc.stdin.write(command + b'\n')
             self.proc.stdin.flush()
-            res = self.proc.stdout.readline()
+            num_lines = int(self.proc.stdout.readline().strip())
+            res = b''.join(self.proc.stdout.readline() for _ in range(num_lines + 1))
             self.result_queue.put_nowait(res[:-1])
             self.queue.task_done()
 
@@ -170,7 +171,12 @@ class AsyncAHKDaemon(AsyncAHK):
             command = await self.queue.get()
             self.proc.stdin.write(command + b'\n')
             await self.proc.stdin.drain()
-            res = await self.proc.stdout.readline()
+            num_lines = int(await self.proc.stdout.readline())
+            lines = []
+            for _ in range(num_lines + 1):
+                line = await self.proc.stdout.readline()
+                lines.append(line)
+            res = b''.join(lines)
             self.result_queue.put_nowait(res[:-1])
             self.queue.task_done()
 

--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -495,7 +495,12 @@ AHKWinGetPos(ByRef command) {
     return s
 }
 
-
+CountNewlines(ByRef s) {
+    newline := "`n"
+    StringReplace, s, s, %newline%, %newline%, UseErrorLevel
+    count := ErrorLevel
+    return count
+}
 
 stdin  := FileOpen("*", "r `n")  ; Requires [v1.1.17+]
 
@@ -504,6 +509,8 @@ Loop {
         commandArray := StrSplit(query, ",")
         func := commandArray[1]
         response := %func%(commandArray)
+        newline_count := CountNewlines(response)
+        FileAppend, %newline_count%`n, *
         FileAppend, %response%`n, *
 }
 

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -245,7 +245,7 @@ WinActivate(ByRef command) {
     if (command.Length() = 2) {
         WinActivate, %title%
     } else {
-        secondstowait = command[3]
+        secondstowait := command[3]
         WinActivate, %title%, %secondstowait%
     }
 }
@@ -255,7 +255,7 @@ WinActivateBottom(ByRef command) {
     if (command.Length() = 2) {
         WinActivateBottom, %title%
     } else {
-        secondstowait = command[3]
+        secondstowait := command[3]
         WinActivateBottom, %title%, %secondstowait%
     }
 }
@@ -265,7 +265,7 @@ WinClose(ByRef command) {
     if (command.Length() = 2) {
         WinClose,% title
     } else {
-        secondstowait = command[3]
+        secondstowait := command[3]
         WinClose, %title%, %secondstowait%
     }
 }
@@ -275,7 +275,7 @@ WinHide(ByRef command) {
     if (command.Length() = 2) {
         WinHide, %title%
     } else {
-        secondstowait = command[3]
+        secondstowait := command[3]
         WinHide, %title%, %secondstowait%
     }
 }
@@ -285,7 +285,7 @@ WinKill(ByRef command) {
     if (command.Length() = 2) {
         WinKill, %title%
     } else {
-        secondstowait = command[3]
+        secondstowait := command[3]
         WinKill, %title%, %secondstowait%
     }
 }
@@ -295,7 +295,7 @@ WinMaximize(ByRef command) {
     if (command.Length() = 2) {
         WinMaximize, %title%
     } else {
-        secondstowait = command[3]
+        secondstowait := command[3]
         WinMaximize, %title%, %secondstowait%
     }
 }
@@ -305,7 +305,7 @@ WinMinimize(ByRef command) {
     if (command.Length() = 2) {
         WinMinimize, %title%
     } else {
-        secondstowait = command[3]
+        secondstowait := command[3]
         WinMinimize, %title%, %secondstowait%
     }
 }
@@ -315,7 +315,7 @@ WinRestore(ByRef command) {
     if (command.Length() = 2) {
         WinRestore, %title%
     } else {
-        secondstowait = command[3]
+        secondstowait := command[3]
         WinRestore, %title%, %secondstowait%
     }
 }
@@ -325,7 +325,7 @@ WinShow(ByRef command) {
     if (command.Length() = 2) {
         WinShow, %title%
     } else {
-        secondstowait = command[3]
+        secondstowait := command[3]
         WinShow, %title%, %secondstowait%
     }
 }
@@ -345,7 +345,7 @@ WinWaitActive(ByRef command) {
     if (command.Length() = 2) {
         WinWaitActive, %title%
     } else {
-        secondstowait = command[3]
+        secondstowait := command[3]
         WinWaitActive, %title%, %secondstowait%
     }
 }
@@ -365,7 +365,7 @@ WinWaitClose(ByRef command) {
     if (command.Length() = 2) {
         WinWaitClose, %title%
     } else {
-        secondstowait = command[3]
+        secondstowait := command[3]
         WinWaitClose, %title%, %secondstowait%
     }
 }
@@ -503,7 +503,12 @@ AHKWinGetPos(ByRef command) {
     return s
 }
 
-
+CountNewlines(ByRef s) {
+    newline := "`n"
+    StringReplace, s, s, %newline%, %newline%, UseErrorLevel
+    count := ErrorLevel
+    return count
+}
 
 stdin  := FileOpen("*", "r `n")  ; Requires [v1.1.17+]
 
@@ -512,5 +517,7 @@ Loop {
         commandArray := StrSplit(query, ",")
         func := commandArray[1]
         response := %func%(commandArray)
+        newline_count := CountNewlines(response)
+        FileAppend, %newline_count%`n, *
         FileAppend, %response%`n, *
 }

--- a/tests/unittests/test_daemon.py
+++ b/tests/unittests/test_daemon.py
@@ -76,6 +76,17 @@ class TestKeyboardDaemon(TestCase):
         self.ahk.set_capslock_state("on")
         assert self.ahk.key_state("CapsLock", "T")
 
+    def test_multi_line_response(self):
+        """
+        Test that responses with multi-line strings are not truncated
+        Not really a 'keyboard' test, but whatever
+        """
+        self.notepad.activate()
+        self.ahk.type('Hello\nWorld!')
+        assert b'Hello' in self.notepad.text
+        assert b'World!' in self.notepad.text
+
+
 class TestMouseDaemon(TestCase):
     def setUp(self) -> None:
         self.ahk = AHKDaemon()

--- a/tests/unittests/test_daemon.py
+++ b/tests/unittests/test_daemon.py
@@ -83,7 +83,7 @@ class TestKeyboardDaemon(TestCase):
         """
         self.notepad.activate()
         self.ahk.type('Hello\nWorld!')
-        assert b'Hello' in self.notepad.text
+        assert b'Hello\r\n' in self.notepad.text
         assert b'World!' in self.notepad.text
 
 

--- a/tests/unittests/test_daemon_async.py
+++ b/tests/unittests/test_daemon_async.py
@@ -234,3 +234,16 @@ class TestKeyboardDaemonAsync(IsolatedAsyncioTestCase):
         await notepad.activate()
         await self.ahk.type("Hello, World!")
         assert b"Hello, World!" in await notepad.get_text()
+
+    async def test_multi_line_response(self):
+        """
+        Test that responses with multi-line strings are not truncated
+        Not really a 'keyboard' test, but whatever
+        """
+        notepad = await self.ahk.find_window(title=b"Untitled - Notepad")
+        await notepad.activate()
+        await self.ahk.type('Hello\nWorld!')
+        text = await notepad.get_text()
+        assert b'Hello' in text
+        assert b'World!' in text
+

--- a/tests/unittests/test_daemon_async.py
+++ b/tests/unittests/test_daemon_async.py
@@ -244,6 +244,6 @@ class TestKeyboardDaemonAsync(IsolatedAsyncioTestCase):
         await notepad.activate()
         await self.ahk.type('Hello\nWorld!')
         text = await notepad.get_text()
-        assert b'Hello' in text
+        assert b'Hello\r\n' in text
         assert b'World!' in text
 


### PR DESCRIPTION
Currently, the (async) daemon does not correctly handle responses containing a newline (for example, when retrieving the text of a window that contains multiple lines). By accidental implementation detail, the synchronous daemon does not have this problem.

Adds new protocol in order to handle responses that contain multiple lines.

The protocol essentially works like this:

1. The request is sent as a command, terminated by a newline, to the stdin of the AHK daemon process. Commands never contain literal newlines.
2. The daemon will read the command from stdin to determine which function to execute (so far, this is the same as previously)
3. AHK will count the number of newlines in the response, then send that number to stdout, terminated by a newline, followed by the payload, terminated by a final newline.  
4. Python will read the first line to determine how many lines it expects in the response. It will then read that many lines (+1 for the terminal newline) to form the response from the daemon's stdout.

Request/response format stated as ebnf:

```ebnf
digit = "<any digit 0-9>"
character = "<any character, excluding line endings>"
terminal = "\n" | "\r\n"
anycharacter = character | terminal
command = character , {character}
request = command , terminal
response = digit , {digit} , terminal , {anycharacter} , terminal
```
