### PR TITLE
Add UTF-8 codepage explicitly

### DIFF
--- a/ahk/script.py
+++ b/ahk/script.py
@@ -132,7 +132,7 @@ class ScriptEngine(object):
 
     def _run_script(self, script_text, **kwargs):
         blocking = kwargs.pop('blocking', True)
-        runargs = [self.executable_path, '/ErrorStdOut', '*']
+        runargs = [self.executable_path, '/CP65001', '/ErrorStdOut', '*']
         decode = kwargs.pop('decode', False)
         script_bytes = bytes(script_text, 'utf-8')
         if blocking:
@@ -159,7 +159,7 @@ class ScriptEngine(object):
         blocking = kwargs.pop('blocking', True)
         if blocking is not True:
             warnings.warn('blocking=False will probably result in problems', stacklevel=2)
-        runargs = [self.executable_path, '/ErrorStdOut', '*']
+        runargs = [self.executable_path, '/CP65001', '/ErrorStdOut', '*']
         proc = await asyncio.subprocess.create_subprocess_exec(
             *runargs, stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
         )


### PR DESCRIPTION
Resolves #132 

This also impacts related issues like #146 and #45

Setting the codepage explicitly means that scripts sent to AHK are correctly interpreted as UTF-8

This means UTF-8 text will be able to be sent with methods like `send`, `send_input`, etc and be correctly interpreted.

This does not affect behavior in the case where Daemon mode is used (AHK still interprets stdin using system encoding). In which case, the workaround of using unicode escape sequences is required.