### PR TITLE
specify UTF8 for all outputs

### DIFF
--- a/ahk/templates/_daemon.ahk
+++ b/ahk/templates/_daemon.ahk
@@ -533,6 +533,6 @@ Loop {
         func := commandArray[1]
         response := %func%(commandArray)
         newline_count := CountNewlines(response)
-        FileAppend, %newline_count%`n, *
-        FileAppend, %response%`n, *
+        FileAppend, %newline_count%`n, *, UTF-8
+        FileAppend, %response%`n, *, UTF-8
 }

--- a/ahk/templates/asynchotkey.ahk
+++ b/ahk/templates/asynchotkey.ahk
@@ -1,6 +1,6 @@
 {% extends "base.ahk" %}
 {% block body %}
 {{ hotkey }}::
-    FileAppend, `n, *
+    FileAppend, `n, *, UTF-8
     return
 {% endblock body %}

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -541,6 +541,6 @@ Loop {
         func := commandArray[1]
         response := %func%(commandArray)
         newline_count := CountNewlines(response)
-        FileAppend, %newline_count%`n, *
-        FileAppend, %response%`n, *
+        FileAppend, %newline_count%`n, *, UTF-8
+        FileAppend, %response%`n, *, UTF-8
 }

--- a/ahk/templates/keyboard/key_state.ahk
+++ b/ahk/templates/keyboard/key_state.ahk
@@ -1,8 +1,8 @@
 {% extends "base.ahk" %}
 {% block body %}
 if (GetKeyState("{{ key_name }}"{% if mode %} , "{{ mode }}"{% endif %})) {
-    FileAppend, 1, *
+    FileAppend, 1, *, UTF-8
 } else {
-    FileAppend, 0, *
+    FileAppend, 0, *, UTF-8
 }
 {% endblock body %}

--- a/ahk/templates/keyboard/key_wait.ahk
+++ b/ahk/templates/keyboard/key_wait.ahk
@@ -2,5 +2,5 @@
 {% block body %}
 KeyWait, {{ key_name }}{% if options %} , {{ options }}{% endif %}
 
-FileAppend, %ErrorLevel%, *
+FileAppend, %ErrorLevel%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/mouse/mouse_position.ahk
+++ b/ahk/templates/mouse/mouse_position.ahk
@@ -3,5 +3,5 @@
 CoordMode,Mouse,{{mode}}
 MouseGetPos, xpos, ypos
 s .= Format("({}, {})", xpos, ypos)
-FileAppend, %s%, *
+FileAppend, %s%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/registery/reg_read.ahk
+++ b/ahk/templates/registery/reg_read.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
 RegRead,output,{{ key_name }},{{ value_name }}
-FileAppend, %output%, *
+FileAppend, %output%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/screen/image_search.ahk
+++ b/ahk/templates/screen/image_search.ahk
@@ -3,5 +3,5 @@
 CoordMode, Pixel, {{ coord_mode }}
 ImageSearch,xpos,ypos,{{ x1 }},{{ y1 }},{{ x2 }},{{ y2 }},{% if options %}{% for option in options %}*{{ option }} {% endfor %}{% endif %}{{ image_path }}
 s .= Format("({}, {})", xpos, ypos)
-FileAppend, %s%, *
+FileAppend, %s%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/screen/pixel_get_color.ahk
+++ b/ahk/templates/screen/pixel_get_color.ahk
@@ -3,5 +3,5 @@
 CoordMode, Pixel, {{ coord_mode }}
 PixelGetColor,color, {{ x }}, {{ y }}{% if options %},{% for option in options %} {{ option }}{% endfor %}{% endif %}
 
-FileAppend, %color%, *
+FileAppend, %color%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/screen/pixel_search.ahk
+++ b/ahk/templates/screen/pixel_search.ahk
@@ -4,5 +4,5 @@ CoordMode, Pixel, {{ coord_mode }}
 PixelSearch, xpos, ypos, {{ x1 }}, {{ y1 }}, {{ x2 }}, {{ y2 }}, {{ color }} , {{ variation }}{% if options %},{% for option in options %} {{ option }}{% endfor %}{% endif %}
 
 s .= Format("({}, {})", xpos, ypos)
-FileAppend, %s%, *
+FileAppend, %s%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/sound/get_volume.ahk
+++ b/ahk/templates/sound/get_volume.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
 SoundGetWaveVolume, retval, {{ device_number }}
-FileAppend, %retval%, *
+FileAppend, %retval%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/sound/sound_get.ahk
+++ b/ahk/templates/sound/sound_get.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
 SoundGet, retval , {{ component_type }}, {{ control_type }}, {{ device_number }}
-FileAppend, %retval%, *
+FileAppend, %retval%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/sound/sound_set.ahk
+++ b/ahk/templates/sound/sound_set.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
 SoundSet, {{ value }}, {{ component_type }}, {{ control_type }}, {{ device_number }}
-FileAppend, %retval%, *
+FileAppend, %retval%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/window/base_check.ahk
+++ b/ahk/templates/window/base_check.ahk
@@ -1,7 +1,7 @@
 {% extends "base.ahk" %}
 {% block body %}
 if {{ command }}("{{ title }}")
-    FileAppend, 1, *
+    FileAppend, 1, *, UTF-8
 else
-    FileAppend, 0, *
+    FileAppend, 0, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/window/base_get_command.ahk
+++ b/ahk/templates/window/base_get_command.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
 {{ command }},text,{{ title }}
-FileAppend, %text%, *
+FileAppend, %text%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/window/from_mouse.ahk
+++ b/ahk/templates/window/from_mouse.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
 MouseGetPos,,, MouseWin
-FileAppend, %MouseWin%, *
+FileAppend, %MouseWin%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/window/get.ahk
+++ b/ahk/templates/window/get.ahk
@@ -1,5 +1,5 @@
 {% extends "base.ahk" %}
 {% block body %}
 WinGet, output,{{ subcommand }},{{ title }},{{ text }},{{ exclude_title }},{{ exclude_text }}
-FileAppend, %output%, *
+FileAppend, %output%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/window/id_list.ahk
+++ b/ahk/templates/window/id_list.ahk
@@ -6,5 +6,5 @@ Loop %windows%
     id := windows%A_Index%
     r .= id . "`,"
 }
-FileAppend, %r%, *
+FileAppend, %r%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/window/title_list.ahk
+++ b/ahk/templates/window/title_list.ahk
@@ -7,5 +7,5 @@ Loop %windows%
     WinGetTitle wt, ahk_id %id%
     r .= wt . "`n"
 }
-FileAppend, %r%, *
+FileAppend, %r%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/window/win_is_always_on_top.ahk
+++ b/ahk/templates/window/win_is_always_on_top.ahk
@@ -2,7 +2,7 @@
 {% block body %}
 WinGet, ExStyle, ExStyle, {{ title }}
 if (ExStyle & 0x8)  ; 0x8 is WS_EX_TOPMOST.
-    FileAppend, 1, *
+    FileAppend, 1, *, UTF-8
 else
-    FileAppend, 0, *
+    FileAppend, 0, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/window/win_position.ahk
+++ b/ahk/templates/window/win_position.ahk
@@ -12,5 +12,5 @@ s .= Format("({})", width)
 {% else %}
 s .= Format("({}, {}, {}, {})", x, y, width, height)
 {% endif %}
-FileAppend, %s%, *
+FileAppend, %s%, *, UTF-8
 {% endblock body %}

--- a/ahk/templates/window/win_wait.ahk
+++ b/ahk/templates/window/win_wait.ahk
@@ -4,6 +4,6 @@ WinWait,{{title}},{{text}},{{timeout}},{{exclude_title}},{{exclude_text}}
 if !ErrorLevel
 {
        WinGet, output, ID
-       FileAppend,%output%,*
+       FileAppend,%output%,*, UTF-8
 }
 {% endblock body %}

--- a/docs/README.md
+++ b/docs/README.md
@@ -262,7 +262,7 @@ Suppose you have a script like so
 ```autohotkey
 #Persistent
 data := "Hello Data!"
-FileAppend, %data%, * ; send data var to stdout
+FileAppend, %data%, *, UTF-8 ; send data var to stdout
 ExitApp
 ```
 


### PR DESCRIPTION
Followup to #150 -- this change should cover the outputs send back from AHK.

It should also make `encoding` parameters obsolete.