### PR TITLE
unasync changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     files: ^(ahk/_async/.*\.py|\.unasync-rewrite\.py|tests/_async/.*\.py)
     pass_filenames: false
     additional_dependencies:
-        - unasync
+        - git+https://github.com/spyoungtech/unasync.git@unasync-remove
         - tokenize_rt
         - black
   - id: set-constants

--- a/.unasync-rewrite.py
+++ b/.unasync-rewrite.py
@@ -1,42 +1,13 @@
-import ast
 import os
 import shutil
 import subprocess
 import sys
 
 import black
-from black import check_stability_and_equivalence
-from tokenize_rt import reversed_enumerate
-from tokenize_rt import src_to_tokens
-from tokenize_rt import tokens_to_src
 
 GIT_EXECUTABLE = shutil.which('git')
 
 changes = 0
-
-
-def _rewrite_file(filename: str) -> int:
-    with open(filename, encoding='UTF-8') as f:
-        contents = f.read()
-    tree = ast.parse(contents, filename=filename)
-    tokens = src_to_tokens(contents)
-    nodes_on_lines_to_remove = []
-    for tok in tokens:
-        if tok.name == 'COMMENT' and 'unasync: remove' in tok.src:
-            nodes_on_lines_to_remove.append(tok.line)
-    lines_to_remove = set()
-    for node in ast.walk(tree):
-        if hasattr(node, 'lineno') and node.lineno in nodes_on_lines_to_remove:
-            for lineno in range(node.lineno, node.end_lineno + 1):
-                lines_to_remove.add(lineno)
-    for i, tok in reversed_enumerate(tokens):
-        if tok.line in lines_to_remove:
-            tokens.pop(i)
-    new_contents = tokens_to_src(tokens)
-    if new_contents != contents:
-        with open(filename, 'w') as f:
-            f.write(new_contents)
-    return new_contents != contents
 
 
 def _copyfunc(src, dst, *, follow_symlinks=True):
@@ -70,17 +41,7 @@ def main() -> int:
     if os.path.isdir('build'):
         shutil.rmtree('build')
     subprocess.run([sys.executable, 'setup.py', 'build_py'], check=True)
-    for root, dirs, files in os.walk('build/lib/ahk/_sync'):
-        for fname in files:
-            if fname.endswith('.py'):
-                fp = os.path.join(root, fname)
-                _rewrite_file(fp)
     subprocess.run([sys.executable, '_tests_setup.py', 'build_py'], check=True)
-    for root, dirs, files in os.walk('build/lib/tests/_sync'):
-        for fname in files:
-            if fname.endswith('.py'):
-                fp = os.path.join(root, fname)
-                _rewrite_file(fp)
     shutil.copytree('build/lib/ahk/_sync', 'ahk/_sync', dirs_exist_ok=True, copy_function=_copyfunc)
     shutil.copytree('build/lib/tests/_sync', 'tests/_sync', dirs_exist_ok=True, copy_function=_copyfunc)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "git+https://github.com/spyoungtech/unasync.git@unasync-remove", "tokenize-rt"]
+requires = ["setuptools", "unasync @ https://github.com/spyoungtech/unasync/archive/refs/heads/unasync-remove.zip", "tokenize-rt"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "unasync", "tokenize-rt"]
+requires = ["setuptools", "git+https://github.com/spyoungtech/unasync.git@unasync-remove", "tokenize-rt"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 
 name = ahk
-version = 1.1.0rc1
+version = 1.1.0rc2
 author_email = spencer.young@spyoung.com
 author = Spencer Young
 description = A Python wrapper for AHK


### PR DESCRIPTION
Update for including new version of `unasync` which will support `unasync: remove` comments -- so the custom logic can be removed from this project.

Should also allow us to use `python -m build` correctly (instead of needing to do `python setup.py sdist bdist_wheel`

Resolves #195