### PR TITLE
#199 - ensure image path is always passed in image_search

### DIFF
--- a/ahk/_async/engine.py
+++ b/ahk/_async/engine.py
@@ -2701,6 +2701,10 @@ class AsyncAHK:
             args.append(opts + f' {image_path}')
         else:
             args.append(image_path)
+
+        if coord_mode is not None:
+            args.append(coord_mode)
+
         resp = await self._transport.function_call('AHKImageSearch', args, blocking=blocking)
         return resp
 

--- a/ahk/_async/engine.py
+++ b/ahk/_async/engine.py
@@ -2698,7 +2698,7 @@ class AsyncAHK:
         args = [str(x1), str(y1), str(x2), str(y2)]
         if options:
             opts = ' '.join(f'*{opt}' for opt in options)
-            args.append(opts)
+            args.append(opts + f' {image_path}')
         else:
             args.append(image_path)
         resp = await self._transport.function_call('AHKImageSearch', args, blocking=blocking)

--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -1577,6 +1577,11 @@ AHKWinSetTransColor(ByRef command) {
 
 
     WinSet, TransColor, %color%, %title%, %text%, %extitle%, %extext%
+
+    DetectHiddenWindows, %current_detect_hw%
+    SetTitleMatchMode, %current_match_mode%
+    SetTitleMatchMode, %current_match_speed%
+
     return FormatNoValueResponse()
     {% endblock AHKWinSetTransColor %}
 }

--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -161,11 +161,13 @@ AHKWinClose(ByRef command) {
         DetectHiddenWindows, %detect_hw%
     }
 
+
+    WinClose, %title%, %text%, %secondstowait%, %extitle%, %extext%
+
     DetectHiddenWindows, %current_detect_hw%
     SetTitleMatchMode, %current_match_mode%
     SetTitleMatchMode, %current_match_speed%
 
-    WinClose, %title%, %text%, %secondstowait%, %extitle%, %extext%
 
     return FormatNoValueResponse()
     {% endblock AHKWinClose %}

--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -1590,6 +1590,13 @@ AHKImageSearch(ByRef command) {
     y1 := command[3]
     x2 := command[4]
     y2 := command[5]
+    coord_mode := command[7]
+
+    current_mode := Format("{}", A_CoordModePixel)
+
+    if (coord_mode != "") {
+        CoordMode, Pixel, %coord_mode%
+    }
 
     if (x2 = "A_ScreenWidth") {
         x2 := A_ScreenWidth
@@ -1597,7 +1604,15 @@ AHKImageSearch(ByRef command) {
     if (y2 = "A_ScreenHeight") {
         y2 := A_ScreenHeight
     }
+
     ImageSearch, xpos, ypos,% x1,% y1,% x2,% y2, %imagepath%
+
+
+    if (coord_mode != "") {
+        CoordMode, Pixel, %current_mode%
+    }
+
+
     if (ErrorLevel = 2) {
         s := FormatResponse(EXCEPTIONRESPONSEMESSAGE, "there was a problem that prevented the command from conducting the search (such as failure to open the image file or a badly formatted option)")
     } else if (ErrorLevel = 1) {

--- a/ahk/_sync/engine.py
+++ b/ahk/_sync/engine.py
@@ -2690,6 +2690,9 @@ class AHK:
             args.append(opts + f' {image_path}')
         else:
             args.append(image_path)
+
+        if coord_mode is not None:
+            args.append(coord_mode)
         resp = self._transport.function_call('AHKImageSearch', args, blocking=blocking)
         return resp
 

--- a/ahk/_sync/engine.py
+++ b/ahk/_sync/engine.py
@@ -2687,7 +2687,7 @@ class AHK:
         args = [str(x1), str(y1), str(x2), str(y2)]
         if options:
             opts = ' '.join(f'*{opt}' for opt in options)
-            args.append(opts)
+            args.append(opts + f' {image_path}')
         else:
             args.append(image_path)
         resp = self._transport.function_call('AHKImageSearch', args, blocking=blocking)

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -158,11 +158,13 @@ AHKWinClose(ByRef command) {
         DetectHiddenWindows, %detect_hw%
     }
 
+
+    WinClose, %title%, %text%, %secondstowait%, %extitle%, %extext%
+
     DetectHiddenWindows, %current_detect_hw%
     SetTitleMatchMode, %current_match_mode%
     SetTitleMatchMode, %current_match_speed%
 
-    WinClose, %title%, %text%, %secondstowait%, %extitle%, %extext%
 
     return FormatNoValueResponse()
     {% endblock AHKWinClose %}

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -1587,6 +1587,13 @@ AHKImageSearch(ByRef command) {
     y1 := command[3]
     x2 := command[4]
     y2 := command[5]
+    coord_mode := command[7]
+
+    current_mode := Format("{}", A_CoordModePixel)
+
+    if (coord_mode != "") {
+        CoordMode, Pixel, %coord_mode%
+    }
 
     if (x2 = "A_ScreenWidth") {
         x2 := A_ScreenWidth
@@ -1594,7 +1601,15 @@ AHKImageSearch(ByRef command) {
     if (y2 = "A_ScreenHeight") {
         y2 := A_ScreenHeight
     }
+
     ImageSearch, xpos, ypos,% x1,% y1,% x2,% y2, %imagepath%
+
+
+    if (coord_mode != "") {
+        CoordMode, Pixel, %current_mode%
+    }
+
+
     if (ErrorLevel = 2) {
         s := FormatResponse(EXCEPTIONRESPONSEMESSAGE, "there was a problem that prevented the command from conducting the search (such as failure to open the image file or a badly formatted option)")
     } else if (ErrorLevel = 1) {

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -1574,6 +1574,11 @@ AHKWinSetTransColor(ByRef command) {
 
 
     WinSet, TransColor, %color%, %title%, %text%, %extitle%, %extext%
+
+    DetectHiddenWindows, %current_detect_hw%
+    SetTitleMatchMode, %current_match_mode%
+    SetTitleMatchMode, %current_match_speed%
+
     return FormatNoValueResponse()
     {% endblock AHKWinSetTransColor %}
 }

--- a/tests/_async/test_screen.py
+++ b/tests/_async/test_screen.py
@@ -64,6 +64,16 @@ class TestScreen(IsolatedAsyncioTestCase):
         x2, y2 = pos
         assert abs(x2 - x) < 3 and abs(y2 - y) < 3
 
+    async def test_image_search_with_option(self):
+        if os.environ.get('CI'):
+            self.skipTest('This test does not work in GitHub Actions')
+            return
+        self._show_in_thread()
+        time.sleep(3)
+        self.im.save('testimage.png')
+        position = await self.ahk.image_search('testimage.png', color_variation=50)
+        assert isinstance(position, tuple)
+
     # async def test_pixel_get_color(self):
     #     x, y = await self.ahk.pixel_search(0xFF0000)
     #     result = await self.ahk.pixel_get_color(x, y)

--- a/tests/_sync/test_screen.py
+++ b/tests/_sync/test_screen.py
@@ -64,6 +64,16 @@ class TestScreen(TestCase):
         x2, y2 = pos
         assert abs(x2 - x) < 3 and abs(y2 - y) < 3
 
+    def test_image_search_with_option(self):
+        if os.environ.get('CI'):
+            self.skipTest('This test does not work in GitHub Actions')
+            return
+        self._show_in_thread()
+        time.sleep(3)
+        self.im.save('testimage.png')
+        position = self.ahk.image_search('testimage.png', color_variation=50)
+        assert isinstance(position, tuple)
+
     # async def test_pixel_get_color(self):
     #     x, y = await self.ahk.pixel_search(0xFF0000)
     #     result = await self.ahk.pixel_get_color(x, y)


### PR DESCRIPTION
Resolves #199 

Squashed a bug where the image path is not passed to AHK when any of the keyword arguments to `image_search` which map to `ImageFile` options for `ImageSearch`  (e.g., `color_variation`,  `scale_height`, `transparent`, etc.) are provided.

Also includes a few other bug fixes:

- fixes the coord_mode argument for `ImageSearch` (previously ignored)
- fixes a bug where global state can be erroneously changed (not reverted) in the AHK implementation for `win_set_trans_color`
- fixes a bug where global state modifiers are not respected for the AHK implementation for `win_close`

