### PR TITLE
Improve protocol error messaging

### DIFF
--- a/ahk/_async/transport.py
+++ b/ahk/_async/transport.py
@@ -720,7 +720,13 @@ class AsyncDaemonProcessTransport(AsyncTransport):
             content_buffer = BytesIO()
             content_buffer.write(tom)
             content_buffer.write(num_lines)
-            for _ in range(int(num_lines) + 1):
+            try:
+                lines_to_read = int(num_lines) + 1
+            except ValueError as e:
+                raise AHKProtocolError(
+                    'Unexpected data received. This is usually the result of an unhandled error in the AHK process.'
+                ) from e
+            for _ in range(lines_to_read):
                 part = await proc.readline()
                 content_buffer.write(part)
             content = content_buffer.getvalue()[:-1]
@@ -767,10 +773,10 @@ class AsyncDaemonProcessTransport(AsyncTransport):
         content_buffer.write(num_lines)
         try:
             lines_to_read = int(num_lines) + 1
-        except ValueError:
+        except ValueError as e:
             raise AHKProtocolError(
                 'Unexpected data received. This is usually the result of an unhandled error in the AHK process.'
-            )
+            ) from e
         for _ in range(lines_to_read):
             part = await self._proc.readline()
             content_buffer.write(part)

--- a/ahk/_sync/transport.py
+++ b/ahk/_sync/transport.py
@@ -694,7 +694,13 @@ class DaemonProcessTransport(Transport):
             content_buffer = BytesIO()
             content_buffer.write(tom)
             content_buffer.write(num_lines)
-            for _ in range(int(num_lines) + 1):
+            try:
+                lines_to_read = int(num_lines) + 1
+            except ValueError as e:
+                raise AHKProtocolError(
+                    'Unexpected data received. This is usually the result of an unhandled error in the AHK process.'
+                ) from e
+            for _ in range(lines_to_read):
                 part = proc.readline()
                 content_buffer.write(part)
             content = content_buffer.getvalue()[:-1]
@@ -733,10 +739,10 @@ class DaemonProcessTransport(Transport):
         content_buffer.write(num_lines)
         try:
             lines_to_read = int(num_lines) + 1
-        except ValueError:
+        except ValueError as e:
             raise AHKProtocolError(
                 'Unexpected data received. This is usually the result of an unhandled error in the AHK process.'
-            )
+            ) from e
         for _ in range(lines_to_read):
             part = self._proc.readline()
             content_buffer.write(part)


### PR DESCRIPTION
A small change to improve error messages raised when a protocol error occurs.

Specifically:

1. `AHKProtocolError` is now raised `from` the original ValueError exception
2. non-blocking requests now raise `AHKProtocolError` instead of `ValueError`

