### PR TITLE
Allow directives to be specified for hotkey process

### DIFF
--- a/ahk/_async/transport.py
+++ b/ahk/_async/transport.py
@@ -337,7 +337,7 @@ class AsyncTransport(ABC):
         **kwargs: Any,
     ):
         self._executable_path: str = _resolve_executable_path(executable_path=executable_path)
-        self._hotkey_transport = ThreadedHotkeyTransport(executable_path=self._executable_path)
+        self._hotkey_transport = ThreadedHotkeyTransport(executable_path=self._executable_path, directives=directives)
         self._directives: list[Union[Directive, Type[Directive]]] = directives or []
 
     def on_clipboard_change(

--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -2777,6 +2777,10 @@ Loop {
 """
 
 HOTKEYS_SCRIPT_TEMPLATE = r"""#Persistent
+{% for directive in directives %}
+{% if directive.apply_to_hotkeys_process %}{{ directive }}{% endif %}
+{% endfor %}
+
 {% if on_clipboard %}
 OnClipboardChange("ClipChanged")
 {% endif %}

--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -2778,7 +2778,10 @@ Loop {
 
 HOTKEYS_SCRIPT_TEMPLATE = r"""#Persistent
 {% for directive in directives %}
-{% if directive.apply_to_hotkeys_process %}{{ directive }}{% endif %}
+{% if directive.apply_to_hotkeys_process %}
+
+{{ directive }}
+{% endif %}
 {% endfor %}
 
 {% if on_clipboard %}

--- a/ahk/_hotkey.py
+++ b/ahk/_hotkey.py
@@ -75,7 +75,7 @@ class HotkeyTransportBase(ABC):
         self._clipboard_ex_handler: Optional[Callable[[int, Exception], Any]] = None
         if directives is None:
             directives = []
-        self._directives: list[Directive | Type[Directive]] = directives
+        self._directives: list[Directive | Type[Directive]] = [d for d in directives if d.apply_to_hotkeys_process]
 
     @property
     def _callback_registry(self) -> Dict[str, Union[Hotkey, Hotstring]]:

--- a/ahk/_sync/transport.py
+++ b/ahk/_sync/transport.py
@@ -318,7 +318,7 @@ class Transport(ABC):
         **kwargs: Any,
     ):
         self._executable_path: str = _resolve_executable_path(executable_path=executable_path)
-        self._hotkey_transport = ThreadedHotkeyTransport(executable_path=self._executable_path)
+        self._hotkey_transport = ThreadedHotkeyTransport(executable_path=self._executable_path, directives=directives)
         self._directives: list[Union[Directive, Type[Directive]]] = directives or []
 
     def on_clipboard_change(
@@ -358,9 +358,6 @@ class Transport(ABC):
     def clear_hotstrings(self) -> None:
         self._hotkey_transport.clear_hotstrings()
         return None
-
-
-
 
     def start_hotkeys(self) -> None:
         return self._hotkey_transport.start()

--- a/ahk/directives.py
+++ b/ahk/directives.py
@@ -21,6 +21,10 @@ class DirectiveMeta(type):
     def __eq__(cls, other: Any) -> bool:
         return bool(str(cls) == other)
 
+    @property
+    def apply_to_hotkeys_process(cls) -> bool:
+        return False
+
 
 class Directive(SimpleNamespace, metaclass=DirectiveMeta):
     """

--- a/ahk/directives.py
+++ b/ahk/directives.py
@@ -30,7 +30,8 @@ class Directive(SimpleNamespace, metaclass=DirectiveMeta):
     """
 
     def __init__(self, **kwargs: Any):
-        super().__init__(name=self.name, **kwargs)
+        apply_to_hotkeys = kwargs.pop('apply_to_hotkeys_process', False)
+        super().__init__(name=self.name, apply_to_hotkeys_process=apply_to_hotkeys, **kwargs)
         self._kwargs = kwargs
 
     @property

--- a/ahk/templates/hotkeys.ahk
+++ b/ahk/templates/hotkeys.ahk
@@ -1,6 +1,9 @@
 #Persistent
 {% for directive in directives %}
-{% if directive.apply_to_hotkeys_process %}{{ directive }}{% endif %}
+{% if directive.apply_to_hotkeys_process %}
+
+{{ directive }}
+{% endif %}
 {% endfor %}
 
 {% if on_clipboard %}

--- a/ahk/templates/hotkeys.ahk
+++ b/ahk/templates/hotkeys.ahk
@@ -1,4 +1,8 @@
 #Persistent
+{% for directive in directives %}
+{% if directive.apply_to_hotkeys_process %}{{ directive }}{% endif %}
+{% endfor %}
+
 {% if on_clipboard %}
 OnClipboardChange("ClipChanged")
 {% endif %}

--- a/docs/README.md
+++ b/docs/README.md
@@ -337,6 +337,20 @@ ahk = AHK(directives=[NoTrayIcon])
 
 By default, some directives are automatically added to ensure functionality and are merged with any user-provided directives.
 
+Directives are not applied for the AHK process used for handling hotkeys and hotstrings (discussed below) by default. To apply a directive
+to the hotkeys process using the keyword argument `apply_to_hotkeys_process=True`:
+
+```python
+from ahk import AHK
+from ahk.directives import NoTrayIcon
+
+directives = [
+    NoTrayIcon(apply_to_hotkeys_process=True)
+]
+
+ahk = AHK(directives=directives)
+```
+
 ## Menu tray icon
 
 As discussed above, you can hide the tray icon if you wish. Additionally, there are some methods available for

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 
 name = ahk
-version = 1.2.0rc1
+version = 1.2.0rc2
 author_email = spencer.young@spyoung.com
 author = Spencer Young
 description = A Python wrapper for AHK


### PR DESCRIPTION
Resolves #211 

Related to #216 

Adds the ability for directives to be specified for the hotkey process.

----

Proposed interface:

For any directive, add the keyword `apply_to_hotkeys_process=True` to have the directive apply to the hotkey/hotstring process.

```python
from ahk.directives import NoTrayIcon

directives = [
    NoTrayIcon(apply_to_hotkeys_process=True)
]

ahk = AHK(directives=directives)
```

----

Technically this leaks an implementation detail into the abstraction, but we can fix that in a v2 release if needed. For now, I think practicality beats purity.