### PR TITLE
gui methods

### DIFF
--- a/ahk/__init__.py
+++ b/ahk/__init__.py
@@ -7,8 +7,23 @@ from ._async import AsyncWindow
 from ._sync import AHK
 from ._sync import Control
 from ._sync import Window
+from ._utils import MsgBoxButtons
+from ._utils import MsgBoxDefaultButton
+from ._utils import MsgBoxIcon
+from ._utils import MsgBoxModality
 
-__all__ = ['AHK', 'Window', 'AsyncWindow', 'AsyncAHK', 'Control', 'AsyncControl']
+__all__ = [
+    'AHK',
+    'Window',
+    'AsyncWindow',
+    'AsyncAHK',
+    'Control',
+    'AsyncControl',
+    'MsgBoxButtons',
+    'MsgBoxDefaultButton',
+    'MsgBoxIcon',
+    'MsgBoxModality',
+]
 
 _global_instance: Optional[AHK] = None
 

--- a/ahk/_async/engine.py
+++ b/ahk/_async/engine.py
@@ -3551,6 +3551,59 @@ class AsyncAHK:
             args.append(str(timeout))
         return await self._transport.function_call('AHKMsgBox', args, blocking=blocking)
 
+    # fmt: off
+    @overload
+    async def input_box(self, prompt: str = '', title: str = 'Input', default: str = '', hide: bool = False, width: Optional[int] = None, height: Optional[int] = None, x: Optional[int] = None, y: Optional[int] = None, locale: bool = True, timeout: Optional[int] = None) -> Union[None, str]: ...
+    @overload
+    async def input_box(self, prompt: str = '', title: str = 'Input', default: str = '', hide: bool = False, width: Optional[int] = None, height: Optional[int] = None, x: Optional[int] = None, y: Optional[int] = None, locale: bool = True, timeout: Optional[int] = None, *, blocking: Literal[False]) -> Union[AsyncFutureResult[str], AsyncFutureResult[None]]: ...
+    @overload
+    async def input_box(self, prompt: str = '', title: str = 'Input', default: str = '', hide: bool = False, width: Optional[int] = None, height: Optional[int] = None, x: Optional[int] = None, y: Optional[int] = None, locale: bool = True, timeout: Optional[int] = None, *, blocking: Literal[True]) -> Union[str, None]: ...
+    @overload
+    async def input_box(self, prompt: str = '', title: str = 'Input', default: str = '', hide: bool = False, width: Optional[int] = None, height: Optional[int] = None, x: Optional[int] = None, y: Optional[int] = None, locale: bool = True, timeout: Optional[int] = None, *, blocking: bool = True) -> Union[str, None, AsyncFutureResult[str], AsyncFutureResult[None]]: ...
+    # fmt: on
+    async def input_box(
+        self,
+        prompt: str = '',
+        title: str = 'Input',
+        default: str = '',
+        hide: bool = False,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        locale: bool = True,
+        timeout: Optional[int] = None,
+        *,
+        blocking: bool = True,
+    ) -> Union[None, str, AsyncFutureResult[str], AsyncFutureResult[None]]:
+        """
+        Like AHK's ``InputBox``
+
+        If the user presses Cancel or closes the box, ``None`` is returned.
+        Otherwise, the user's input is returned.
+        Raises a ``TimeoutError`` if a timeout is specified and expires.
+        """
+        args = [title, prompt]
+        if hide:
+            args.append('hide')
+        else:
+            args.append('')
+        for opt in (width, height, x, y):
+            if opt is not None:
+                args.append(str(opt))
+            else:
+                args.append('')
+        if locale:
+            args.append('Locale')
+        else:
+            args.append('')
+        if timeout is not None:
+            args.append(str(timeout))
+        else:
+            args.append('')
+        args.append(default)
+        return await self._transport.function_call('AHKInputBox', args, blocking=blocking)
+
     async def block_forever(self) -> NoReturn:
         """
         Blocks (sleeps) forever. Utility method to prevent script from exiting.

--- a/ahk/_async/engine.py
+++ b/ahk/_async/engine.py
@@ -3494,22 +3494,6 @@ class AsyncAHK:
             args.append(value_name)
         return await self._transport.function_call('AHKRegRead', args, blocking=blocking)
 
-    # XXX: the main auto-execute loop in the daemon will prevent user interaction with a GUI
-    #      This needs to be addressed before implementing general gui functionality
-    # async def _new_gui(self, title: str, options: Optional[List[str]] = None) -> str:
-    #     if options is not None:
-    #         options.append('+Hwndhwnd')
-    #         arg_options = ' '.join(options)
-    #     else:
-    #         arg_options = '+Hwndhwnd'
-    #
-    #     args = [arg_options, title]
-    #     return await self._transport.function_call('AHKGuiNew', args, engine=self)
-    #
-    # async def new_gui(self, title: str, options: Optional[List[str]] = None) -> AsyncGui:
-    #     hwnd = await self._new_gui(title=title, options=options)
-    #     return AsyncGui(engine=self, hwnd=hwnd)
-
     # fmt: off
     @overload
     async def msg_box(self, text: str = '', title: str = 'Message', buttons: MsgBoxButtons = MsgBoxButtons.OK, icon: Optional[MsgBoxIcon] = None, default_button: Optional[MsgBoxDefaultButton] = None, modality: Optional[MsgBoxModality] = None, help_button: bool = False, text_right_justified: bool = False, right_to_left_reading: bool = False, timeout: Optional[int] = None) -> str: ...

--- a/ahk/_async/engine.py
+++ b/ahk/_async/engine.py
@@ -3604,6 +3604,52 @@ class AsyncAHK:
         args.append(default)
         return await self._transport.function_call('AHKInputBox', args, blocking=blocking)
 
+    # fmt: off
+    @overload
+    async def file_select_box(self, title: str = 'Select File', multi: bool = False, root: str = '', filter: str = '', save_button: bool = False, file_must_exist: bool = False, path_must_exist: bool = False, prompt_create_new_file: bool = False, prompt_override_file: bool = False, follow_shortcuts: bool = True) -> Union[None, str]: ...
+    @overload
+    async def file_select_box(self, title: str = 'Select File', multi: bool = False, root: str = '', filter: str = '', save_button: bool = False, file_must_exist: bool = False, path_must_exist: bool = False, prompt_create_new_file: bool = False, prompt_override_file: bool = False, follow_shortcuts: bool = True, *, blocking: Literal[False]) -> Union[AsyncFutureResult[str], AsyncFutureResult[None]]: ...
+    @overload
+    async def file_select_box(self, title: str = 'Select File', multi: bool = False, root: str = '', filter: str = '', save_button: bool = False, file_must_exist: bool = False, path_must_exist: bool = False, prompt_create_new_file: bool = False, prompt_override_file: bool = False, follow_shortcuts: bool = True, *, blocking: Literal[True]) -> Union[str, None]: ...
+    @overload
+    async def file_select_box(self, title: str = 'Select File', multi: bool = False, root: str = '', filter: str = '', save_button: bool = False, file_must_exist: bool = False, path_must_exist: bool = False, prompt_create_new_file: bool = False, prompt_override_file: bool = False, follow_shortcuts: bool = True, *, blocking: bool = True) -> Union[str, None, AsyncFutureResult[str], AsyncFutureResult[None]]: ...
+    # fmt: on
+    async def file_select_box(
+        self,
+        title: str = 'Select File',
+        multi: bool = False,
+        root: str = '',
+        filter: str = '',
+        save_button: bool = False,
+        file_must_exist: bool = False,
+        path_must_exist: bool = False,
+        prompt_create_new_file: bool = False,
+        prompt_override_file: bool = False,
+        follow_shortcuts: bool = True,
+        *,
+        blocking: bool = True,
+    ) -> Union[str, None, AsyncFutureResult[str], AsyncFutureResult[None]]:
+        opts = 0
+        if file_must_exist:
+            opts += 1
+        if path_must_exist:
+            opts += 2
+        if prompt_create_new_file:
+            opts += 8
+        if prompt_override_file:
+            opts += 8
+        if not follow_shortcuts:
+            opts += 32
+        options = ''
+        if multi:
+            options += 'M'
+        if save_button:
+            options += 'S'
+        if opts:
+            options += str(opts)
+        args = [options, root, title, filter]
+        return await self._transport.function_call('AHKFileSelectFile', args, blocking=blocking)
+
     async def block_forever(self) -> NoReturn:
         """
         Blocks (sleeps) forever. Utility method to prevent script from exiting.

--- a/ahk/_async/engine.py
+++ b/ahk/_async/engine.py
@@ -3650,6 +3650,43 @@ class AsyncAHK:
         args = [options, root, title, filter]
         return await self._transport.function_call('AHKFileSelectFile', args, blocking=blocking)
 
+    # fmt: off
+    @overload
+    async def folder_select_box(self, prompt: str = 'Select Folder', root: str = '', chroot: bool = False, enable_new_directories: bool = True, edit_field: bool = False, new_dialog_style: bool = False) -> Union[None, str]: ...
+    @overload
+    async def folder_select_box(self, prompt: str = 'Select Folder', root: str = '', chroot: bool = False, enable_new_directories: bool = True, edit_field: bool = False, new_dialog_style: bool = False, *, blocking: Literal[False]) -> Union[AsyncFutureResult[str], AsyncFutureResult[None]]: ...
+    @overload
+    async def folder_select_box(self, prompt: str = 'Select Folder', root: str = '', chroot: bool = False, enable_new_directories: bool = True, edit_field: bool = False, new_dialog_style: bool = False, *, blocking: Literal[True]) -> Union[str, None]: ...
+    @overload
+    async def folder_select_box(self, prompt: str = 'Select Folder', root: str = '', chroot: bool = False, enable_new_directories: bool = True, edit_field: bool = False, new_dialog_style: bool = False, *, blocking: bool = True) -> Union[str, None, AsyncFutureResult[str], AsyncFutureResult[None]]: ...
+    # fmt: on
+    async def folder_select_box(
+        self,
+        prompt: str = 'Select Folder',
+        root: str = '',
+        chroot: bool = False,
+        enable_new_directories: bool = True,
+        edit_field: bool = False,
+        new_dialog_style: bool = False,
+        *,
+        blocking: bool = True,
+    ) -> Union[str, None, AsyncFutureResult[str], AsyncFutureResult[None]]:
+        if not chroot:
+            starting_folder = '*'
+        else:
+            starting_folder = ''
+        starting_folder += root
+        if enable_new_directories:
+            opts = 1
+        else:
+            opts = 0
+        if edit_field:
+            opts += 2
+        if new_dialog_style:
+            opts += 4
+        args = [starting_folder, str(opts), prompt]
+        return await self._transport.function_call('AHKFileSelectFolder', args, blocking=blocking)
+
     async def block_forever(self) -> NoReturn:
         """
         Blocks (sleeps) forever. Utility method to prevent script from exiting.

--- a/ahk/_async/transport.py
+++ b/ahk/_async/transport.py
@@ -95,6 +95,7 @@ FunctionName = Literal[
     'AHKGetVolume',
     'AHKGuiNew',
     'AHKImageSearch',
+    'AHKInputBox',
     'AHKKeyState',
     'AHKKeyWait',
     'AHKMenuTrayIcon',
@@ -597,6 +598,8 @@ class AsyncTransport(ABC):
     async def function_call(self, function_name: Literal['AHKGuiNew'], args: List[str], *, engine: AsyncAHK) -> str: ...
     @overload
     async def function_call(self, function_name: Literal['AHKMsgBox'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, AsyncFutureResult[str]]: ...
+    @overload
+    async def function_call(self, function_name: Literal['AHKInputBox'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, None, AsyncFutureResult[str], AsyncFutureResult[None]]: ...
     # fmt: on
 
     async def function_call(

--- a/ahk/_async/transport.py
+++ b/ahk/_async/transport.py
@@ -86,6 +86,7 @@ FunctionName = Literal[
     'AHKControlGetPos',
     'AHKControlGetText',
     'AHKControlSend',
+    'AHKFileSelectFile',
     'AHKGetClipboard',
     'AHKGetClipboardAll',
     'AHKGetCoordMode',
@@ -600,6 +601,9 @@ class AsyncTransport(ABC):
     async def function_call(self, function_name: Literal['AHKMsgBox'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, AsyncFutureResult[str]]: ...
     @overload
     async def function_call(self, function_name: Literal['AHKInputBox'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, None, AsyncFutureResult[str], AsyncFutureResult[None]]: ...
+    @overload
+    async def function_call(self, function_name: Literal['AHKFileSelectFile'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, None, AsyncFutureResult[str], AsyncFutureResult[None]]: ...
+
     # fmt: on
 
     async def function_call(

--- a/ahk/_async/transport.py
+++ b/ahk/_async/transport.py
@@ -93,12 +93,14 @@ FunctionName = Literal[
     'AHKGetTitleMatchMode',
     'AHKGetTitleMatchSpeed',
     'AHKGetVolume',
+    'AHKGuiNew',
     'AHKImageSearch',
     'AHKKeyState',
     'AHKKeyWait',
     'AHKMenuTrayIcon',
     'AHKMenuTrayShow',
     'AHKMenuTrayTip',
+    'AHKMsgBox',
     'AHKMouseClickDrag',
     'AHKMouseGetPos',
     'AHKMouseMove',
@@ -591,7 +593,10 @@ class AsyncTransport(ABC):
     async def function_call(self, function_name: Literal['AHKMenuTrayIcon'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[None, AsyncFutureResult[None]]: ...
     @overload
     async def function_call(self, function_name: Literal['AHKMenuTrayShow'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[None, AsyncFutureResult[None]]: ...
-
+    @overload
+    async def function_call(self, function_name: Literal['AHKGuiNew'], args: List[str], *, engine: AsyncAHK) -> str: ...
+    @overload
+    async def function_call(self, function_name: Literal['AHKMsgBox'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, AsyncFutureResult[str]]: ...
     # fmt: on
 
     async def function_call(

--- a/ahk/_async/transport.py
+++ b/ahk/_async/transport.py
@@ -87,6 +87,7 @@ FunctionName = Literal[
     'AHKControlGetText',
     'AHKControlSend',
     'AHKFileSelectFile',
+    'AHKFileSelectFolder',
     'AHKGetClipboard',
     'AHKGetClipboardAll',
     'AHKGetCoordMode',
@@ -603,7 +604,8 @@ class AsyncTransport(ABC):
     async def function_call(self, function_name: Literal['AHKInputBox'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, None, AsyncFutureResult[str], AsyncFutureResult[None]]: ...
     @overload
     async def function_call(self, function_name: Literal['AHKFileSelectFile'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, None, AsyncFutureResult[str], AsyncFutureResult[None]]: ...
-
+    @overload
+    async def function_call(self, function_name: Literal['AHKFileSelectFolder'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, None, AsyncFutureResult[str], AsyncFutureResult[None]]: ...
     # fmt: on
 
     async def function_call(

--- a/ahk/_async/window.py
+++ b/ahk/_async/window.py
@@ -743,3 +743,21 @@ class AsyncControl:
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} window={self.window!r}, control_hwnd={self.hwnd!r}, control_class={self.control_class!r}>'
+
+
+#
+# class AsyncGui:
+#     def __init__(self, engine: AsyncAHK, hwnd: str):
+#         self._engine = engine
+#         self._hwnd: str = hwnd
+#
+#     @property
+#     def hwnd(self) -> str:
+#         return self._hwnd
+#
+#     @classmethod
+#     async def new(cls, engine: AsyncAHK, title: str, options: Optional[list[str]] = None) -> AsyncGui:
+#         return await engine.new_gui(title=title, options=options)
+#
+#     def to_window(self) -> AsyncWindow:
+#         return AsyncWindow(engine=self._engine, ahk_id=self.hwnd)

--- a/ahk/_async/window.py
+++ b/ahk/_async/window.py
@@ -743,21 +743,3 @@ class AsyncControl:
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} window={self.window!r}, control_hwnd={self.hwnd!r}, control_class={self.control_class!r}>'
-
-
-#
-# class AsyncGui:
-#     def __init__(self, engine: AsyncAHK, hwnd: str):
-#         self._engine = engine
-#         self._hwnd: str = hwnd
-#
-#     @property
-#     def hwnd(self) -> str:
-#         return self._hwnd
-#
-#     @classmethod
-#     async def new(cls, engine: AsyncAHK, title: str, options: Optional[list[str]] = None) -> AsyncGui:
-#         return await engine.new_gui(title=title, options=options)
-#
-#     def to_window(self) -> AsyncWindow:
-#         return AsyncWindow(engine=self._engine, ahk_id=self.hwnd)

--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -2684,7 +2684,6 @@ AHKMsgBox(ByRef command) {
 }
 
 AHKInputBox(ByRef command) {
-    global INTEGERRESPONSEMESSAGE
     global STRINGRESPONSEMESSAGE
     global TIMEOUTRESPONSEMESSAGE
     title := command[2]
@@ -2702,6 +2701,21 @@ AHKInputBox(ByRef command) {
     if (ErrorLevel = 2) {
         ret := FormatResponse(TIMEOUTRESPONSEMESSAGE, "Input box timed out")
     } else if (ErrorLevel = 1) {
+        ret := FormatNoValueResponse()
+    } else {
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, output)
+    }
+    return ret
+}
+
+AHKFileSelectFile(byRef command) {
+    global STRINGRESPONSEMESSAGE
+    options := command[2]
+    root := command[3]
+    title := command[4]
+    filter := command[5]
+    FileSelectFile, output, %options%, %root%, %title%, %filter%
+    if (ErrorLevel = 1) {
         ret := FormatNoValueResponse()
     } else {
         ret := FormatResponse(STRINGRESPONSEMESSAGE, output)

--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -2683,6 +2683,32 @@ AHKMsgBox(ByRef command) {
     return ret
 }
 
+AHKInputBox(ByRef command) {
+    global INTEGERRESPONSEMESSAGE
+    global STRINGRESPONSEMESSAGE
+    global TIMEOUTRESPONSEMESSAGE
+    title := command[2]
+    prompt := command[3]
+    hide := command[4]
+    width := command[5]
+    height := command[6]
+    x := command[7]
+    y := command[8]
+    locale := command[9]
+    timeout := command[10]
+    default := command[11]
+
+    InputBox, output, %title%, %prompt%, %hide%, %width%, %height%, %x%, %y%, %locale%, %timeout%, %default%
+    if (ErrorLevel = 2) {
+        ret := FormatResponse(TIMEOUTRESPONSEMESSAGE, "Input box timed out")
+    } else if (ErrorLevel = 1) {
+        ret := FormatNoValueResponse()
+    } else {
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, output)
+    }
+    return ret
+}
+
 b64decode(ByRef pszString) {
     ; TODO load DLL globally for performance
     ; REF: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptstringtobinaryw

--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -2723,6 +2723,22 @@ AHKFileSelectFile(byRef command) {
     return ret
 }
 
+AHKFileSelectFolder(byRef command) {
+    global STRINGRESPONSEMESSAGE
+    starting_folder := command[2]
+    options := command[3]
+    prompt := command[4]
+
+    FileSelectFolder, output, %starting_folder%, %options%, %prompt%
+
+    if (ErrorLevel = 1) {
+        ret := FormatNoValueResponse()
+    } else {
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, output)
+    }
+    return ret
+}
+
 b64decode(ByRef pszString) {
     ; TODO load DLL globally for performance
     ; REF: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptstringtobinaryw

--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -2644,6 +2644,45 @@ AHKMenuTrayIcon(ByRef command) {
     return FormatNoValueResponse()
 }
 
+AHKGuiNew(ByRef command) {
+    global STRINGRESPONSEMESSAGE
+    options := command[2]
+    title := command[3]
+    Gui, New, %options%, %title%
+    return FormatResponse(STRINGRESPONSEMESSAGE, hwnd)
+}
+
+AHKMsgBox(ByRef command) {
+    global TIMEOUTRESPONSEMESSAGE
+    global STRINGRESPONSEMESSAGE
+    options := command[2]
+    title := command[3]
+    text := command[4]
+    timeout := command[5]
+    MsgBox,% options, %title%, %text%, %timeout%
+    IfMsgBox, Yes
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "Yes")
+    IfMsgBox, No
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "No")
+    IfMsgBox, OK
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "OK")
+    IfMsgBox, Cancel
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "Cancel")
+    IfMsgBox, Abort
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "Abort")
+    IfMsgBox, Ignore
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "Ignore")
+    IfMsgBox, Retry
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "Retry")
+    IfMsgBox, Continue
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "Continue")
+    IfMsgBox, TryAgain
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "TryAgain")
+    IfMsgBox, Timeout
+        ret := FormatResponse(TIMEOUTRESPONSEMESSAGE, "MsgBox timed out")
+    return ret
+}
+
 b64decode(ByRef pszString) {
     ; TODO load DLL globally for performance
     ; REF: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptstringtobinaryw

--- a/ahk/_sync/engine.py
+++ b/ahk/_sync/engine.py
@@ -3603,7 +3603,21 @@ class AHK:
     @overload
     def file_select_box(self, title: str = 'Select File', multi: bool = False, root: str = '', filter: str = '', save_button: bool = False, file_must_exist: bool = False, path_must_exist: bool = False, prompt_create_new_file: bool = False, prompt_override_file: bool = False, follow_shortcuts: bool = True, *, blocking: bool = True) -> Union[str, None, FutureResult[str], FutureResult[None]]: ...
     # fmt: on
-    def file_select_box(self, title: str = 'Select File', multi: bool = False, root: str = '', filter: str = '', save_button: bool = False, file_must_exist: bool = False, path_must_exist: bool = False, prompt_create_new_file: bool = False, prompt_override_file: bool = False, follow_shortcuts: bool = True, *, blocking: bool = True) -> Union[str, None, FutureResult[str], FutureResult[None]]:
+    def file_select_box(
+        self,
+        title: str = 'Select File',
+        multi: bool = False,
+        root: str = '',
+        filter: str = '',
+        save_button: bool = False,
+        file_must_exist: bool = False,
+        path_must_exist: bool = False,
+        prompt_create_new_file: bool = False,
+        prompt_override_file: bool = False,
+        follow_shortcuts: bool = True,
+        *,
+        blocking: bool = True,
+    ) -> Union[str, None, FutureResult[str], FutureResult[None]]:
         opts = 0
         if file_must_exist:
             opts += 1
@@ -3625,7 +3639,42 @@ class AHK:
         args = [options, root, title, filter]
         return self._transport.function_call('AHKFileSelectFile', args, blocking=blocking)
 
-
+    # fmt: off
+    @overload
+    def folder_select_box(self, prompt: str = 'Select Folder', root: str = '', chroot: bool = False, enable_new_directories: bool = True, edit_field: bool = False, new_dialog_style: bool = False) -> Union[None, str]: ...
+    @overload
+    def folder_select_box(self, prompt: str = 'Select Folder', root: str = '', chroot: bool = False, enable_new_directories: bool = True, edit_field: bool = False, new_dialog_style: bool = False, *, blocking: Literal[False]) -> Union[FutureResult[str], FutureResult[None]]: ...
+    @overload
+    def folder_select_box(self, prompt: str = 'Select Folder', root: str = '', chroot: bool = False, enable_new_directories: bool = True, edit_field: bool = False, new_dialog_style: bool = False, *, blocking: Literal[True]) -> Union[str, None]: ...
+    @overload
+    def folder_select_box(self, prompt: str = 'Select Folder', root: str = '', chroot: bool = False, enable_new_directories: bool = True, edit_field: bool = False, new_dialog_style: bool = False, *, blocking: bool = True) -> Union[str, None, FutureResult[str], FutureResult[None]]: ...
+    # fmt: on
+    def folder_select_box(
+        self,
+        prompt: str = 'Select Folder',
+        root: str = '',
+        chroot: bool = False,
+        enable_new_directories: bool = True,
+        edit_field: bool = False,
+        new_dialog_style: bool = False,
+        *,
+        blocking: bool = True,
+    ) -> Union[str, None, FutureResult[str], FutureResult[None]]:
+        if not chroot:
+            starting_folder = '*'
+        else:
+            starting_folder = ''
+        starting_folder += root
+        if enable_new_directories:
+            opts = 1
+        else:
+            opts = 0
+        if edit_field:
+            opts += 2
+        if new_dialog_style:
+            opts += 4
+        args = [starting_folder, str(opts), prompt]
+        return self._transport.function_call('AHKFileSelectFolder', args, blocking=blocking)
 
     def block_forever(self) -> NoReturn:
         """

--- a/ahk/_sync/engine.py
+++ b/ahk/_sync/engine.py
@@ -3540,6 +3540,59 @@ class AHK:
             args.append(str(timeout))
         return self._transport.function_call('AHKMsgBox', args, blocking=blocking)
 
+    # fmt: off
+    @overload
+    def input_box(self, prompt: str = '', title: str = 'Input', default: str = '', hide: bool = False, width: Optional[int] = None, height: Optional[int] = None, x: Optional[int] = None, y: Optional[int] = None, locale: bool = True, timeout: Optional[int] = None) -> Union[None, str]: ...
+    @overload
+    def input_box(self, prompt: str = '', title: str = 'Input', default: str = '', hide: bool = False, width: Optional[int] = None, height: Optional[int] = None, x: Optional[int] = None, y: Optional[int] = None, locale: bool = True, timeout: Optional[int] = None, *, blocking: Literal[False]) -> Union[FutureResult[str], FutureResult[None]]: ...
+    @overload
+    def input_box(self, prompt: str = '', title: str = 'Input', default: str = '', hide: bool = False, width: Optional[int] = None, height: Optional[int] = None, x: Optional[int] = None, y: Optional[int] = None, locale: bool = True, timeout: Optional[int] = None, *, blocking: Literal[True]) -> Union[str, None]: ...
+    @overload
+    def input_box(self, prompt: str = '', title: str = 'Input', default: str = '', hide: bool = False, width: Optional[int] = None, height: Optional[int] = None, x: Optional[int] = None, y: Optional[int] = None, locale: bool = True, timeout: Optional[int] = None, *, blocking: bool = True) -> Union[str, None, FutureResult[str], FutureResult[None]]: ...
+    # fmt: on
+    def input_box(
+        self,
+        prompt: str = '',
+        title: str = 'Input',
+        default: str = '',
+        hide: bool = False,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        locale: bool = True,
+        timeout: Optional[int] = None,
+        *,
+        blocking: bool = True,
+    ) -> Union[None, str, FutureResult[str], FutureResult[None]]:
+        """
+        Like AHK's ``InputBox``
+
+        If the user presses Cancel or closes the box, ``None`` is returned.
+        Otherwise, the user's input is returned.
+        Raises a ``TimeoutError`` if a timeout is specified and expires.
+        """
+        args = [title, prompt]
+        if hide:
+            args.append('hide')
+        else:
+            args.append('')
+        for opt in (width, height, x, y):
+            if opt is not None:
+                args.append(str(opt))
+            else:
+                args.append('')
+        if locale:
+            args.append('Locale')
+        else:
+            args.append('')
+        if timeout is not None:
+            args.append(str(timeout))
+        else:
+            args.append('')
+        args.append(default)
+        return self._transport.function_call('AHKInputBox', args, blocking=blocking)
+
     def block_forever(self) -> NoReturn:
         """
         Blocks (sleeps) forever. Utility method to prevent script from exiting.

--- a/ahk/_sync/engine.py
+++ b/ahk/_sync/engine.py
@@ -3593,6 +3593,40 @@ class AHK:
         args.append(default)
         return self._transport.function_call('AHKInputBox', args, blocking=blocking)
 
+    # fmt: off
+    @overload
+    def file_select_box(self, title: str = 'Select File', multi: bool = False, root: str = '', filter: str = '', save_button: bool = False, file_must_exist: bool = False, path_must_exist: bool = False, prompt_create_new_file: bool = False, prompt_override_file: bool = False, follow_shortcuts: bool = True) -> Union[None, str]: ...
+    @overload
+    def file_select_box(self, title: str = 'Select File', multi: bool = False, root: str = '', filter: str = '', save_button: bool = False, file_must_exist: bool = False, path_must_exist: bool = False, prompt_create_new_file: bool = False, prompt_override_file: bool = False, follow_shortcuts: bool = True, *, blocking: Literal[False]) -> Union[FutureResult[str], FutureResult[None]]: ...
+    @overload
+    def file_select_box(self, title: str = 'Select File', multi: bool = False, root: str = '', filter: str = '', save_button: bool = False, file_must_exist: bool = False, path_must_exist: bool = False, prompt_create_new_file: bool = False, prompt_override_file: bool = False, follow_shortcuts: bool = True, *, blocking: Literal[True]) -> Union[str, None]: ...
+    @overload
+    def file_select_box(self, title: str = 'Select File', multi: bool = False, root: str = '', filter: str = '', save_button: bool = False, file_must_exist: bool = False, path_must_exist: bool = False, prompt_create_new_file: bool = False, prompt_override_file: bool = False, follow_shortcuts: bool = True, *, blocking: bool = True) -> Union[str, None, FutureResult[str], FutureResult[None]]: ...
+    # fmt: on
+    def file_select_box(self, title: str = 'Select File', multi: bool = False, root: str = '', filter: str = '', save_button: bool = False, file_must_exist: bool = False, path_must_exist: bool = False, prompt_create_new_file: bool = False, prompt_override_file: bool = False, follow_shortcuts: bool = True, *, blocking: bool = True) -> Union[str, None, FutureResult[str], FutureResult[None]]:
+        opts = 0
+        if file_must_exist:
+            opts += 1
+        if path_must_exist:
+            opts += 2
+        if prompt_create_new_file:
+            opts += 8
+        if prompt_override_file:
+            opts += 8
+        if not follow_shortcuts:
+            opts += 32
+        options = ''
+        if multi:
+            options += 'M'
+        if save_button:
+            options += 'S'
+        if opts:
+            options += str(opts)
+        args = [options, root, title, filter]
+        return self._transport.function_call('AHKFileSelectFile', args, blocking=blocking)
+
+
+
     def block_forever(self) -> NoReturn:
         """
         Blocks (sleeps) forever. Utility method to prevent script from exiting.

--- a/ahk/_sync/engine.py
+++ b/ahk/_sync/engine.py
@@ -3483,22 +3483,6 @@ class AHK:
             args.append(value_name)
         return self._transport.function_call('AHKRegRead', args, blocking=blocking)
 
-    # XXX: the main auto-execute loop in the daemon will prevent user interaction with a GUI
-    #      This needs to be addressed before implementing general gui functionality
-    # async def _new_gui(self, title: str, options: Optional[List[str]] = None) -> str:
-    #     if options is not None:
-    #         options.append('+Hwndhwnd')
-    #         arg_options = ' '.join(options)
-    #     else:
-    #         arg_options = '+Hwndhwnd'
-    #
-    #     args = [arg_options, title]
-    #     return await self._transport.function_call('AHKGuiNew', args, engine=self)
-    #
-    # async def new_gui(self, title: str, options: Optional[List[str]] = None) -> AsyncGui:
-    #     hwnd = await self._new_gui(title=title, options=options)
-    #     return AsyncGui(engine=self, hwnd=hwnd)
-
     # fmt: off
     @overload
     def msg_box(self, text: str = '', title: str = 'Message', buttons: MsgBoxButtons = MsgBoxButtons.OK, icon: Optional[MsgBoxIcon] = None, default_button: Optional[MsgBoxDefaultButton] = None, modality: Optional[MsgBoxModality] = None, help_button: bool = False, text_right_justified: bool = False, right_to_left_reading: bool = False, timeout: Optional[int] = None) -> str: ...

--- a/ahk/_sync/transport.py
+++ b/ahk/_sync/transport.py
@@ -78,6 +78,7 @@ FunctionName = Literal[
     'AHKControlGetPos',
     'AHKControlGetText',
     'AHKControlSend',
+    'AHKFileSelectFile',
     'AHKGetClipboard',
     'AHKGetClipboardAll',
     'AHKGetCoordMode',
@@ -581,6 +582,9 @@ class Transport(ABC):
     def function_call(self, function_name: Literal['AHKMsgBox'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, FutureResult[str]]: ...
     @overload
     def function_call(self, function_name: Literal['AHKInputBox'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, None, FutureResult[str], FutureResult[None]]: ...
+    @overload
+    def function_call(self, function_name: Literal['AHKFileSelectFile'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, None, FutureResult[str], FutureResult[None]]: ...
+
     # fmt: on
 
     def function_call(

--- a/ahk/_sync/transport.py
+++ b/ahk/_sync/transport.py
@@ -85,12 +85,14 @@ FunctionName = Literal[
     'AHKGetTitleMatchMode',
     'AHKGetTitleMatchSpeed',
     'AHKGetVolume',
+    'AHKGuiNew',
     'AHKImageSearch',
     'AHKKeyState',
     'AHKKeyWait',
     'AHKMenuTrayIcon',
     'AHKMenuTrayShow',
     'AHKMenuTrayTip',
+    'AHKMsgBox',
     'AHKMouseClickDrag',
     'AHKMouseGetPos',
     'AHKMouseMove',
@@ -572,7 +574,10 @@ class Transport(ABC):
     def function_call(self, function_name: Literal['AHKMenuTrayIcon'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[None, FutureResult[None]]: ...
     @overload
     def function_call(self, function_name: Literal['AHKMenuTrayShow'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[None, FutureResult[None]]: ...
-
+    @overload
+    def function_call(self, function_name: Literal['AHKGuiNew'], args: List[str], *, engine: AHK) -> str: ...
+    @overload
+    def function_call(self, function_name: Literal['AHKMsgBox'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, FutureResult[str]]: ...
     # fmt: on
 
     def function_call(

--- a/ahk/_sync/transport.py
+++ b/ahk/_sync/transport.py
@@ -87,6 +87,7 @@ FunctionName = Literal[
     'AHKGetVolume',
     'AHKGuiNew',
     'AHKImageSearch',
+    'AHKInputBox',
     'AHKKeyState',
     'AHKKeyWait',
     'AHKMenuTrayIcon',
@@ -578,6 +579,8 @@ class Transport(ABC):
     def function_call(self, function_name: Literal['AHKGuiNew'], args: List[str], *, engine: AHK) -> str: ...
     @overload
     def function_call(self, function_name: Literal['AHKMsgBox'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, FutureResult[str]]: ...
+    @overload
+    def function_call(self, function_name: Literal['AHKInputBox'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, None, FutureResult[str], FutureResult[None]]: ...
     # fmt: on
 
     def function_call(

--- a/ahk/_sync/transport.py
+++ b/ahk/_sync/transport.py
@@ -79,6 +79,7 @@ FunctionName = Literal[
     'AHKControlGetText',
     'AHKControlSend',
     'AHKFileSelectFile',
+    'AHKFileSelectFolder',
     'AHKGetClipboard',
     'AHKGetClipboardAll',
     'AHKGetCoordMode',
@@ -584,7 +585,8 @@ class Transport(ABC):
     def function_call(self, function_name: Literal['AHKInputBox'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, None, FutureResult[str], FutureResult[None]]: ...
     @overload
     def function_call(self, function_name: Literal['AHKFileSelectFile'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, None, FutureResult[str], FutureResult[None]]: ...
-
+    @overload
+    def function_call(self, function_name: Literal['AHKFileSelectFolder'], args: Optional[List[str]] = None, *, blocking: bool = True) -> Union[str, None, FutureResult[str], FutureResult[None]]: ...
     # fmt: on
 
     def function_call(

--- a/ahk/_sync/window.py
+++ b/ahk/_sync/window.py
@@ -635,6 +635,7 @@ class Window:
     def from_mouse_position(cls, engine: AHK) -> Optional[Window]:
         return engine.win_get_from_mouse_position()
 
+
 class Control:
     def __init__(self, window: Window, hwnd: str, control_class: str):
         self.window: Window = window
@@ -721,3 +722,20 @@ class Control:
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} window={self.window!r}, control_hwnd={self.hwnd!r}, control_class={self.control_class!r}>'
+
+#
+# class AsyncGui:
+#     def __init__(self, engine: AsyncAHK, hwnd: str):
+#         self._engine = engine
+#         self._hwnd: str = hwnd
+#
+#     @property
+#     def hwnd(self) -> str:
+#         return self._hwnd
+#
+#     @classmethod
+#     async def new(cls, engine: AsyncAHK, title: str, options: Optional[list[str]] = None) -> AsyncGui:
+#         return await engine.new_gui(title=title, options=options)
+#
+#     def to_window(self) -> AsyncWindow:
+#         return AsyncWindow(engine=self._engine, ahk_id=self.hwnd)

--- a/ahk/_sync/window.py
+++ b/ahk/_sync/window.py
@@ -722,20 +722,3 @@ class Control:
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} window={self.window!r}, control_hwnd={self.hwnd!r}, control_class={self.control_class!r}>'
-
-#
-# class AsyncGui:
-#     def __init__(self, engine: AsyncAHK, hwnd: str):
-#         self._engine = engine
-#         self._hwnd: str = hwnd
-#
-#     @property
-#     def hwnd(self) -> str:
-#         return self._hwnd
-#
-#     @classmethod
-#     async def new(cls, engine: AsyncAHK, title: str, options: Optional[list[str]] = None) -> AsyncGui:
-#         return await engine.new_gui(title=title, options=options)
-#
-#     def to_window(self) -> AsyncWindow:
-#         return AsyncWindow(engine=self._engine, ahk_id=self.hwnd)

--- a/ahk/_utils.py
+++ b/ahk/_utils.py
@@ -1,3 +1,5 @@
+import enum
+
 HOTKEY_ESCAPE_SEQUENCE_MAP = {
     '\n': '`n',
     '\t': '`t',
@@ -34,3 +36,38 @@ def hotkey_escape(s: str) -> str:
 
 def type_escape(s: str) -> str:
     return s.translate(_TRANSLATION_TABLE)
+
+
+class MsgBoxButtons(enum.IntEnum):
+    OK = 0
+    OK_CANCEL = 1
+    ABORT_RETRY_IGNORE = 2
+    YES_NO_CANCEL = 3
+    YES_NO = 4
+    RETRY_CANCEL = 5
+    CANCEL_TRYAGAIN_CONTINUE = 6
+
+
+class MsgBoxIcon(enum.IntEnum):
+    HAND = 16
+    QUESTION = 32
+    EXCLAMATION = 48
+    ASTERISK = 64
+
+
+class MsgBoxDefaultButton(enum.IntEnum):
+    SECOND = 256
+    THIRD = 512
+    FOURTH = 768
+
+
+class MsgBoxModality(enum.IntEnum):
+    SYSTEM_MODAL = 4096
+    TASK_MODAL = 8192
+    ALWAYS_ON_TOP = 262144
+
+
+class MsgBoxOtherOptions(enum.IntEnum):
+    HELP_BUTTON = 16384
+    TEXT_RIGHT_JUSTIFIED = 524288
+    RIGHT_TO_LEFT_READING_ORDER = 1048576

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -2720,6 +2720,22 @@ AHKFileSelectFile(byRef command) {
     return ret
 }
 
+AHKFileSelectFolder(byRef command) {
+    global STRINGRESPONSEMESSAGE
+    starting_folder := command[2]
+    options := command[3]
+    prompt := command[4]
+
+    FileSelectFolder, output, %starting_folder%, %options%, %prompt%
+
+    if (ErrorLevel = 1) {
+        ret := FormatNoValueResponse()
+    } else {
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, output)
+    }
+    return ret
+}
+
 b64decode(ByRef pszString) {
     ; TODO load DLL globally for performance
     ; REF: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptstringtobinaryw

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -2681,7 +2681,6 @@ AHKMsgBox(ByRef command) {
 }
 
 AHKInputBox(ByRef command) {
-    global INTEGERRESPONSEMESSAGE
     global STRINGRESPONSEMESSAGE
     global TIMEOUTRESPONSEMESSAGE
     title := command[2]
@@ -2699,6 +2698,21 @@ AHKInputBox(ByRef command) {
     if (ErrorLevel = 2) {
         ret := FormatResponse(TIMEOUTRESPONSEMESSAGE, "Input box timed out")
     } else if (ErrorLevel = 1) {
+        ret := FormatNoValueResponse()
+    } else {
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, output)
+    }
+    return ret
+}
+
+AHKFileSelectFile(byRef command) {
+    global STRINGRESPONSEMESSAGE
+    options := command[2]
+    root := command[3]
+    title := command[4]
+    filter := command[5]
+    FileSelectFile, output, %options%, %root%, %title%, %filter%
+    if (ErrorLevel = 1) {
         ret := FormatNoValueResponse()
     } else {
         ret := FormatResponse(STRINGRESPONSEMESSAGE, output)

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -2680,6 +2680,32 @@ AHKMsgBox(ByRef command) {
     return ret
 }
 
+AHKInputBox(ByRef command) {
+    global INTEGERRESPONSEMESSAGE
+    global STRINGRESPONSEMESSAGE
+    global TIMEOUTRESPONSEMESSAGE
+    title := command[2]
+    prompt := command[3]
+    hide := command[4]
+    width := command[5]
+    height := command[6]
+    x := command[7]
+    y := command[8]
+    locale := command[9]
+    timeout := command[10]
+    default := command[11]
+
+    InputBox, output, %title%, %prompt%, %hide%, %width%, %height%, %x%, %y%, %locale%, %timeout%, %default%
+    if (ErrorLevel = 2) {
+        ret := FormatResponse(TIMEOUTRESPONSEMESSAGE, "Input box timed out")
+    } else if (ErrorLevel = 1) {
+        ret := FormatNoValueResponse()
+    } else {
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, output)
+    }
+    return ret
+}
+
 b64decode(ByRef pszString) {
     ; TODO load DLL globally for performance
     ; REF: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptstringtobinaryw

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -2641,6 +2641,45 @@ AHKMenuTrayIcon(ByRef command) {
     return FormatNoValueResponse()
 }
 
+AHKGuiNew(ByRef command) {
+    global STRINGRESPONSEMESSAGE
+    options := command[2]
+    title := command[3]
+    Gui, New, %options%, %title%
+    return FormatResponse(STRINGRESPONSEMESSAGE, hwnd)
+}
+
+AHKMsgBox(ByRef command) {
+    global TIMEOUTRESPONSEMESSAGE
+    global STRINGRESPONSEMESSAGE
+    options := command[2]
+    title := command[3]
+    text := command[4]
+    timeout := command[5]
+    MsgBox,% options, %title%, %text%, %timeout%
+    IfMsgBox, Yes
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "Yes")
+    IfMsgBox, No
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "No")
+    IfMsgBox, OK
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "OK")
+    IfMsgBox, Cancel
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "Cancel")
+    IfMsgBox, Abort
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "Abort")
+    IfMsgBox, Ignore
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "Ignore")
+    IfMsgBox, Retry
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "Retry")
+    IfMsgBox, Continue
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "Continue")
+    IfMsgBox, TryAgain
+        ret := FormatResponse(STRINGRESPONSEMESSAGE, "TryAgain")
+    IfMsgBox, Timeout
+        ret := FormatResponse(TIMEOUTRESPONSEMESSAGE, "MsgBox timed out")
+    return ret
+}
+
 b64decode(ByRef pszString) {
     ; TODO load DLL globally for performance
     ; REF: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptstringtobinaryw

--- a/tests/_async/test_gui.py
+++ b/tests/_async/test_gui.py
@@ -26,3 +26,11 @@ class TestGui(unittest.IsolatedAsyncioTestCase):
         assert win is not None
         with pytest.raises(TimeoutError):
             r = await box.result()
+
+    async def test_input_box(self):
+        box = await self.ahk.input_box(prompt='Question', title='prompt', timeout=3, blocking=False)
+        await async_sleep(1)
+        win = await self.ahk.win_get(title='prompt')
+        assert win is not None
+        with pytest.raises(TimeoutError):
+            r = await box.result()

--- a/tests/_async/test_gui.py
+++ b/tests/_async/test_gui.py
@@ -1,0 +1,28 @@
+import asyncio
+import time
+import unittest
+
+import pytest
+
+from ahk import AsyncAHK
+
+async_sleep = asyncio.sleep  # unasync: remove
+
+sleep = time.sleep
+
+
+class TestGui(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.ahk = AsyncAHK()
+
+    async def asyncTearDown(self) -> None:
+        self.ahk._transport._proc.kill()
+        time.sleep(0.2)
+
+    async def test_msg_box(self):
+        box = await self.ahk.msg_box(text='hello', title='test', timeout=3, blocking=False)
+        await async_sleep(1)
+        win = await self.ahk.win_get(title='test')
+        assert win is not None
+        with pytest.raises(TimeoutError):
+            r = await box.result()

--- a/tests/_sync/test_gui.py
+++ b/tests/_sync/test_gui.py
@@ -1,0 +1,27 @@
+import asyncio
+import time
+import unittest
+
+import pytest
+
+from ahk import AHK
+
+
+sleep = time.sleep
+
+
+class TestGui(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ahk = AHK()
+
+    def tearDown(self) -> None:
+        self.ahk._transport._proc.kill()
+        time.sleep(0.2)
+
+    def test_msg_box(self):
+        box = self.ahk.msg_box(text='hello', title='test', timeout=3, blocking=False)
+        sleep(1)
+        win = self.ahk.win_get(title='test')
+        assert win is not None
+        with pytest.raises(TimeoutError):
+            r = box.result()

--- a/tests/_sync/test_gui.py
+++ b/tests/_sync/test_gui.py
@@ -25,3 +25,11 @@ class TestGui(unittest.TestCase):
         assert win is not None
         with pytest.raises(TimeoutError):
             r = box.result()
+
+    def test_input_box(self):
+        box = self.ahk.input_box(prompt='Question', title='prompt', timeout=3, blocking=False)
+        sleep(1)
+        win = self.ahk.win_get(title='prompt')
+        assert win is not None
+        with pytest.raises(TimeoutError):
+            r = box.result()


### PR DESCRIPTION
This PR adds some of the GUI methods from AutoHotkey. Namely:

- `msg_box` as an analog for AHK's `MsgBox`
- `input_box` as an analog for AHK's `InputBox`
- `file_select_box` as an analog for AHK's `FileSelectFile`
- `folder_select_box` as an analog for AHK's `FileSelectFolder`

This PR does _not_ implement the broader `Gui` functions. Because AHK lacks true threading, while AHK is reading stdin for new commands, no other activity can occur in the AHK process. This means that GUI dialogs will fail to respond to user input (causing Windows to indicate 'the application is not responding'). This could be worked around in a similar manner to how we handle hotkeys in a separate process for the same reason -- however, this is decidedly not planned. Python has far more robust options for GUI libraries that users can easily compose into their Python applications.

Closes #11 