### PR TITLE
exclude abstract base class from message registry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     -   id: reorder-python-imports
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.4.1'
+    rev: 'v1.5.1'
     hooks:
     -   id: mypy
         args:

--- a/ahk/message.py
+++ b/ahk/message.py
@@ -143,8 +143,7 @@ class ResponseMessage:
         return NotImplemented
 
 
-_message_registry: dict[bytes, 'ResponseMessageClassTypes']
-_message_registry = {ResponseMessage._type_order_mark: ResponseMessage}
+_message_registry: dict[bytes, 'ResponseMessageClassTypes'] = {}
 
 
 class TupleResponseMessage(ResponseMessage):


### PR DESCRIPTION
A simple fix for a typing issue that was surfaced when upgrading to `mypy` version 1.5.1 where the (abstract) base `ResponseMessage` class was included in the message. The base class is now removed from the registry by default. Since that message type can never be unpacked anyhow (even if the class could be instantiated), this shouldn't cause any incompatibility with previous versions.

Supersedes #227 