### PR TITLE
Add AHK process handling to exit if parent Python process dies unexpectedly

### DIFF
--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -2806,7 +2806,7 @@ Loop {
 
 HOTKEYS_SCRIPT_TEMPLATE = r"""#Requires AutoHotkey v1.1.17+
 #Persistent
-#Warn
+
 {% for directive in directives %}
 {% if directive.apply_to_hotkeys_process %}
 
@@ -2819,7 +2819,7 @@ OnClipboardChange("ClipChanged")
 {% endif %}
 KEEPALIVE := Chr(57344)
 stdin  := FileOpen("*", "r `n", "UTF-8")
-SetTimer, keepalive, 1000
+SetTimer, keepalive, 2000
 
 Crypt32 := DllCall("LoadLibrary", "Str", "Crypt32.dll", "Ptr")
 
@@ -2907,8 +2907,10 @@ keepalive:
     global KEEPALIVE
     global stdin
     FileAppend, %KEEPALIVE%`n, *, UTF-8
-    alivesignal := RTrim(stdin.ReadLine(), "`n")
-    if (alivesignal = "") {
+    alive_message := RTrim(stdin.ReadLine(), "`n")
+    if (alive_message != KEEPALIVE) {
+        ; The parent Python process has terminated unexpectedly
+        ; Exit to avoid leaving the hotkey process around
         ExitApp
     }
     return
@@ -5910,14 +5912,16 @@ ClipChanged(Type) {
 OnClipboardChange(ClipChanged)
 
 {% endif %}
-SetTimer KeepAliveFunc, 1000
+SetTimer KeepAliveFunc, 2000
 
 KeepAliveFunc() {
     global stdin
     global KEEPALIVE
     WriteStdout(Format("{}`n", KEEPALIVE))
-    alivesignal := RTrim(stdin.ReadLine(), "`n")
-    if (alivesignal = "") {
+    alive_message := RTrim(stdin.ReadLine(), "`n")
+    if (alive_message != KEEPALIVE) {
+        ; The parent Python process has terminated unexpectedly
+        ; Exit to avoid leaving the hotkey process around
         ExitApp
     }
     return

--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -2756,6 +2756,7 @@ CommandArrayFromQuery(ByRef text) {
 
 {% endfor %}
 ; END extension scripts
+
 {% block before_autoexecute %}
 {% endblock before_autoexecute %}
 
@@ -2765,6 +2766,15 @@ pyresp := ""
 
 Loop {
     query := RTrim(stdin.ReadLine(), "`n")
+    if (query = "") {
+        ; Technically this should only happen if the Python process has died, so sending a message is probably futile
+        ; But if this somehow triggers in some other case, we'll try to have an informative error raised.
+        pyresp := FormatResponse("ahk.message.ExceptionResponseMessage", "Unexpected empty message; AHK exiting. This is likely a bug. Please report this issue at https://github.com/spyoungtech/ahk/issues")
+        FileAppend, %pyresp%, *, UTF-8
+
+        ; Exit to avoid leaving the process hanging around needlessly
+        ExitApp
+    }
     argsArray := CommandArrayFromQuery(query)
     try {
         func := argsArray[1]
@@ -5744,6 +5754,15 @@ pyresp := ""
 
 Loop {
     query := RTrim(stdin.ReadLine(), "`n")
+    if (query = "") {
+        ; Technically, this should only happen if the Python process has died, so sending a message is probably futile
+        ; But if this somehow triggers in some other case and the Python process is still listening, we'll try to have an informative error raised.
+        pyresp := FormatResponse("ahk.message.ExceptionResponseMessage", "Unexpected empty message; AHK exiting. This is likely a bug. Please report this issue at https://github.com/spyoungtech/ahk/issues")
+        stdout.Write(pyresp)
+        stdout.Read(0)
+        ; Exit to avoid leaving the process hanging around
+        ExitApp
+    }
     argsArray := CommandArrayFromQuery(query)
     try {
         func_name := argsArray[1]

--- a/ahk/_hotkey.py
+++ b/ahk/_hotkey.py
@@ -342,7 +342,7 @@ class ThreadedHotkeyTransport(HotkeyTransportBase):
                 line = self._proc.stdout.readline()
                 if line.rstrip(b'\n') == _KEEPALIVE_SENTINEL:
                     logging.debug('keepalive received')
-                    self._proc.stdin.write(b'alive\n')
+                    self._proc.stdin.write(b'\xee\x80\x80\n')
                     self._proc.stdin.flush()
                     continue
                 if not line.strip():

--- a/ahk/_hotkey.py
+++ b/ahk/_hotkey.py
@@ -336,11 +336,14 @@ class ThreadedHotkeyTransport(HotkeyTransportBase):
                 stderr=subprocess.STDOUT,
             )
             atexit.register(kill, self._proc)
+            assert self._proc.stdout is not None
+            assert self._proc.stdin is not None
             while self._running:
-                assert self._proc.stdout is not None
                 line = self._proc.stdout.readline()
                 if line.rstrip(b'\n') == _KEEPALIVE_SENTINEL:
                     logging.debug('keepalive received')
+                    self._proc.stdin.write(b'alive\n')
+                    self._proc.stdin.flush()
                     continue
                 if not line.strip():
                     logging.debug('Listener: Process probably died, exiting')

--- a/ahk/templates/daemon-v2.ahk
+++ b/ahk/templates/daemon-v2.ahk
@@ -2845,6 +2845,15 @@ pyresp := ""
 
 Loop {
     query := RTrim(stdin.ReadLine(), "`n")
+    if (query = "") {
+        ; Technically, this should only happen if the Python process has died, so sending a message is probably futile
+        ; But if this somehow triggers in some other case and the Python process is still listening, we'll try to have an informative error raised.
+        pyresp := FormatResponse("ahk.message.ExceptionResponseMessage", "Unexpected empty message; AHK exiting. This is likely a bug. Please report this issue at https://github.com/spyoungtech/ahk/issues")
+        stdout.Write(pyresp)
+        stdout.Read(0)
+        ; Exit to avoid leaving the process hanging around
+        ExitApp
+    }
     argsArray := CommandArrayFromQuery(query)
     try {
         func_name := argsArray[1]

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -2753,6 +2753,7 @@ CommandArrayFromQuery(ByRef text) {
 
 {% endfor %}
 ; END extension scripts
+
 {% block before_autoexecute %}
 {% endblock before_autoexecute %}
 
@@ -2762,6 +2763,15 @@ pyresp := ""
 
 Loop {
     query := RTrim(stdin.ReadLine(), "`n")
+    if (query = "") {
+        ; Technically this should only happen if the Python process has died, so sending a message is probably futile
+        ; But if this somehow triggers in some other case, we'll try to have an informative error raised.
+        pyresp := FormatResponse("ahk.message.ExceptionResponseMessage", "Unexpected empty message; AHK exiting. This is likely a bug. Please report this issue at https://github.com/spyoungtech/ahk/issues")
+        FileAppend, %pyresp%, *, UTF-8
+
+        ; Exit to avoid leaving the process hanging around needlessly
+        ExitApp
+    }
     argsArray := CommandArrayFromQuery(query)
     try {
         func := argsArray[1]

--- a/ahk/templates/hotkeys-v2.ahk
+++ b/ahk/templates/hotkeys-v2.ahk
@@ -8,9 +8,9 @@
 
 
 KEEPALIVE := Chr(57344)
-;SetTimer, keepalive, 1000
 
 stdout := FileOpen("*", "w", "UTF-8")
+stdin  := FileOpen("*", "r `n", "UTF-8")
 
 WriteStdout(s) {
     global stdout
@@ -105,8 +105,15 @@ ClipChanged(Type) {
 OnClipboardChange(ClipChanged)
 
 {% endif %}
+SetTimer KeepAliveFunc, 1000
 
-
-;keepalive:
-;global KEEPALIVE
-;FileAppend, %KEEPALIVE%`n, *, UTF-8
+KeepAliveFunc() {
+    global stdin
+    global KEEPALIVE
+    WriteStdout(Format("{}`n", KEEPALIVE))
+    alivesignal := RTrim(stdin.ReadLine(), "`n")
+    if (alivesignal = "") {
+        ExitApp
+    }
+    return
+}

--- a/ahk/templates/hotkeys-v2.ahk
+++ b/ahk/templates/hotkeys-v2.ahk
@@ -105,14 +105,16 @@ ClipChanged(Type) {
 OnClipboardChange(ClipChanged)
 
 {% endif %}
-SetTimer KeepAliveFunc, 1000
+SetTimer KeepAliveFunc, 2000
 
 KeepAliveFunc() {
     global stdin
     global KEEPALIVE
     WriteStdout(Format("{}`n", KEEPALIVE))
-    alivesignal := RTrim(stdin.ReadLine(), "`n")
-    if (alivesignal = "") {
+    alive_message := RTrim(stdin.ReadLine(), "`n")
+    if (alive_message != KEEPALIVE) {
+        ; The parent Python process has terminated unexpectedly
+        ; Exit to avoid leaving the hotkey process around
         ExitApp
     }
     return

--- a/ahk/templates/hotkeys.ahk
+++ b/ahk/templates/hotkeys.ahk
@@ -1,5 +1,6 @@
 #Requires AutoHotkey v1.1.17+
 #Persistent
+#Warn
 {% for directive in directives %}
 {% if directive.apply_to_hotkeys_process %}
 
@@ -11,6 +12,7 @@
 OnClipboardChange("ClipChanged")
 {% endif %}
 KEEPALIVE := Chr(57344)
+stdin  := FileOpen("*", "r `n", "UTF-8")
 SetTimer, keepalive, 1000
 
 Crypt32 := DllCall("LoadLibrary", "Str", "Crypt32.dll", "Ptr")
@@ -96,5 +98,11 @@ ClipChanged(Type) {
 
 
 keepalive:
-global KEEPALIVE
-FileAppend, %KEEPALIVE%`n, *, UTF-8
+    global KEEPALIVE
+    global stdin
+    FileAppend, %KEEPALIVE%`n, *, UTF-8
+    alivesignal := RTrim(stdin.ReadLine(), "`n")
+    if (alivesignal = "") {
+        ExitApp
+    }
+    return

--- a/ahk/templates/hotkeys.ahk
+++ b/ahk/templates/hotkeys.ahk
@@ -1,6 +1,6 @@
 #Requires AutoHotkey v1.1.17+
 #Persistent
-#Warn
+
 {% for directive in directives %}
 {% if directive.apply_to_hotkeys_process %}
 
@@ -13,7 +13,7 @@ OnClipboardChange("ClipChanged")
 {% endif %}
 KEEPALIVE := Chr(57344)
 stdin  := FileOpen("*", "r `n", "UTF-8")
-SetTimer, keepalive, 1000
+SetTimer, keepalive, 2000
 
 Crypt32 := DllCall("LoadLibrary", "Str", "Crypt32.dll", "Ptr")
 
@@ -101,8 +101,10 @@ keepalive:
     global KEEPALIVE
     global stdin
     FileAppend, %KEEPALIVE%`n, *, UTF-8
-    alivesignal := RTrim(stdin.ReadLine(), "`n")
-    if (alivesignal = "") {
+    alive_message := RTrim(stdin.ReadLine(), "`n")
+    if (alive_message != KEEPALIVE) {
+        ; The parent Python process has terminated unexpectedly
+        ; Exit to avoid leaving the hotkey process around
         ExitApp
     }
     return

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,8 @@ print(ahk.mouse_position)  #  (150, 150)
 
 # Examples
 
-Non-exhaustive examples of some functions available with this package. Full documentation coming soon!
+Non-exhaustive examples of some functions available with this package. See the [full documentation](https://ahk.readthedocs.io/en/latest/?badge=latest)
+for complete API references and additional features.
 
 ## Hotkeys
 


### PR DESCRIPTION
Resolves #257 

Normally, when Python exits it will cleanup any of the AHK subprocesses that were created. This is handled by `atexit` handlers. However, if the Python process is terminated abruptly in a manner that prevents `atexit` handlers from running, the AHK process(es) will not be reaped and will continue running (or in the case of AHK v2, the daemon will throw an error then exit).

This PR changes the AHK daemon script logic to call `ExitApp` to exit gracefully in the case where the parent Python process exits unexpectedly (instead of continuing the loop endlessly in v1 or raising an error message in v2). This is done by assuming that when `stdin.ReadLine()` returns empty it is because the parent Python process died. This is the only case where the message is known to be empty.

TODO:

- [x] Add handling to exit hotkey process(es) when Python parent process dies.
