### PR TITLE
Consider adding a curly bracket ("{}") check for the Key class

### DIFF
--- a/ahk/keys.py
+++ b/ahk/keys.py
@@ -23,11 +23,19 @@ class Key:
 
     @property
     def DOWN(self) -> str:
-        return '{' + f'{self.name} down' + '}'
+        nameLen = len(self.name)
+        if '{' == self.name[0] and nameLen > 1: # don't add extra curly brackets if already braced 
+            return f'{self.name[0:nameLen-1]} down' + '}'
+        else:
+            return '{' + f'{self.name} down' + '}'
 
     @property
     def UP(self) -> str:
-        return '{' + f'{self.name} up' + '}'
+        nameLen = len(self.name)
+        if '{' == self.name[0] and nameLen > 1: # don't add extra curly brackets if already braced 
+            return f'{self.name[0:nameLen-1]} up' + '}'
+        else:
+            return '{' + f'{self.name} up' + '}'
 
     def __str__(self) -> str:
         return '{' + self.name + '}'


### PR DESCRIPTION
I'm working on a project that allows its users to customize their key configurations. Here's a snippet:
```
def move_forward(forwardKey : str) # forwardKey is a valid key
  ahk.send(forwardKey)
  ahk.key_down(forwardKey)
  sleep(1)
  ahk.key_up(forwardKey)
```
Since key strings such as `'up'` and `'shift'` need curly brackets (`{}`) when passed to `ahk.send()`, I simply give a pair of curly brackets to the `forwardKey` string no matter what they are (e.g. `'a'` becomes `'{a}'`, `'up'` becomes `'{up}'`).

Problem is, the `Key.DOWN`/`UP` property also automatically adds a pair of curly brackets, e.g.:
```
from ahk import AHK, keys
k = keys.Key(key_name='{up}')
print(k.DOWN) # prints {{up} down}
```

So, in the `move_forward()` function, 
1. if `forwardKey == 'up'`, then `ahk.send(forwardKey)` will not work as expected (sends 'u' and 'p' instead of the up arrow key);
2. if `forwardKey == '{up}'`, then `ahk.key_down(forwardKey)` will not work because it's equivalent to `ahk.send('{{up} down}')`.

This PR aims to fix this issue - probably not very gracefully :/