### PR TITLE
GH-264 fix mouse_drag error when using AutoHotkey v2

### DIFF
--- a/ahk/_async/engine.py
+++ b/ahk/_async/engine.py
@@ -2901,7 +2901,7 @@ class AsyncAHK(Generic[T_AHKVersion]):
         *,
         from_position: Optional[Tuple[int, int]] = None,
         speed: Optional[int] = None,
-        button: MouseButton = 1,
+        button: MouseButton = 'left',
         relative: Optional[bool] = None,
         blocking: bool = True,
         coord_mode: Optional[CoordModeRelativeTo] = None,
@@ -2927,6 +2927,8 @@ class AsyncAHK(Generic[T_AHKVersion]):
 
         if coord_mode:
             args.append(coord_mode)
+        else:
+            args.append('')
 
         await self._transport.function_call('AHKMouseClickDrag', args, blocking=blocking)
 

--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -4815,7 +4815,17 @@ AHKMouseClickDrag(args*) {
         CoordMode("Mouse", relative_to)
     }
 
-    MouseClickDrag(button, x1, y1, x2, y2, speed, relative)
+    if (speed = "") {
+        speed := A_DefaultMouseSpeed
+    }
+
+    if (x1 = "" and y1 = "") {
+        MouseClickDrag(button, , , x2, y2, speed, relative)
+    }
+    else {
+        MouseClickDrag(button, x1, y1, x2, y2, speed, relative)
+    }
+
 
     if (relative_to != "") {
         CoordMode("Mouse", current_coord_rel)

--- a/ahk/_sync/engine.py
+++ b/ahk/_sync/engine.py
@@ -2889,7 +2889,7 @@ class AHK(Generic[T_AHKVersion]):
         *,
         from_position: Optional[Tuple[int, int]] = None,
         speed: Optional[int] = None,
-        button: MouseButton = 1,
+        button: MouseButton = 'left',
         relative: Optional[bool] = None,
         blocking: bool = True,
         coord_mode: Optional[CoordModeRelativeTo] = None,
@@ -2915,6 +2915,8 @@ class AHK(Generic[T_AHKVersion]):
 
         if coord_mode:
             args.append(coord_mode)
+        else:
+            args.append('')
 
         self._transport.function_call('AHKMouseClickDrag', args, blocking=blocking)
 

--- a/ahk/templates/daemon-v2.ahk
+++ b/ahk/templates/daemon-v2.ahk
@@ -1896,7 +1896,17 @@ AHKMouseClickDrag(args*) {
         CoordMode("Mouse", relative_to)
     }
 
-    MouseClickDrag(button, x1, y1, x2, y2, speed, relative)
+    if (speed = "") {
+        speed := A_DefaultMouseSpeed
+    }
+
+    if (x1 = "" and y1 = "") {
+        MouseClickDrag(button, , , x2, y2, speed, relative)
+    }
+    else {
+        MouseClickDrag(button, x1, y1, x2, y2, speed, relative)
+    }
+
 
     if (relative_to != "") {
         CoordMode("Mouse", current_coord_rel)


### PR DESCRIPTION
Fixes a bug (not passing required number of arguments) in the `mouse_drag` function that caused the function to error when used with AutoHotkey version 2. Also fixes subsequent API incompatibilities between AHK v1 and v2.

Resolves #264