### PR TITLE
fix key_state for AHKv2 when no mode argument is given

### DIFF
--- a/ahk/_async/engine.py
+++ b/ahk/_async/engine.py
@@ -1101,6 +1101,8 @@ class AsyncAHK(Generic[T_AHKVersion]):
             if mode not in ('T', 'P'):
                 raise ValueError(f'Invalid value for mode parameter. Mode must be `T` or `P`. Got {mode!r}')
             args.append(mode)
+        else:
+            args.append('')
         resp = await self._transport.function_call('AHKKeyState', args, blocking=blocking)
         return resp
 

--- a/ahk/_sync/engine.py
+++ b/ahk/_sync/engine.py
@@ -1089,6 +1089,8 @@ class AHK(Generic[T_AHKVersion]):
             if mode not in ('T', 'P'):
                 raise ValueError(f'Invalid value for mode parameter. Mode must be `T` or `P`. Got {mode!r}')
             args.append(mode)
+        else:
+            args.append('')
         resp = self._transport.function_call('AHKKeyState', args, blocking=blocking)
         return resp
 


### PR DESCRIPTION
Resolves #277 

When using the `key_state` method with AutoHotkey v2, when the `mode` keyword argument is omitted, this produces an error. The argument array becomes undersized and, in AutoHotkey v2, this produces an error when trying to access the argument.