### PR TITLE
GH-289 fix message box in AHKv2

### DIFF
--- a/ahk/_async/engine.py
+++ b/ahk/_async/engine.py
@@ -3756,6 +3756,9 @@ class AsyncAHK(Generic[T_AHKVersion]):
         args = [str(options), title, text]
         if timeout is not None:
             args.append(str(timeout))
+        else:
+            args.append('')
+
         return await self._transport.function_call('AHKMsgBox', args, blocking=blocking)
 
     # fmt: off

--- a/ahk/_sync/engine.py
+++ b/ahk/_sync/engine.py
@@ -3744,6 +3744,9 @@ class AHK(Generic[T_AHKVersion]):
         args = [str(options), title, text]
         if timeout is not None:
             args.append(str(timeout))
+        else:
+            args.append('')
+
         return self._transport.function_call('AHKMsgBox', args, blocking=blocking)
 
     # fmt: off


### PR DESCRIPTION
Fixes a problem where `msg_box` has missing arguments for the underlying call to AHKMsgBox, which results in an error being thrown when using AHKv2.

Resolves #289 