### PR TITLE
fix clip_wait in AHKv2

### DIFF
--- a/ahk/_async/engine.py
+++ b/ahk/_async/engine.py
@@ -3630,6 +3630,8 @@ class AsyncAHK(Generic[T_AHKVersion]):
         args = [str(timeout) if timeout else '']
         if wait_for_any_data:
             args.append('1')
+        else:
+            args.append('0')
         return await self._transport.function_call('AHKClipWait', args, blocking=blocking)
 
     async def block_input(

--- a/ahk/_sync/engine.py
+++ b/ahk/_sync/engine.py
@@ -3618,6 +3618,8 @@ class AHK(Generic[T_AHKVersion]):
         args = [str(timeout) if timeout else '']
         if wait_for_any_data:
             args.append('1')
+        else:
+            args.append('0')
         return self._transport.function_call('AHKClipWait', args, blocking=blocking)
 
     def block_input(


### PR DESCRIPTION
When the `wait_for_any_data` keyword is omitted from `clip_wait`, in AutoHotkey v2, an error is thrown. This PR resolves this issue by ensuring the proper number of arguments are passed.