### PR TITLE
typing improvements

### DIFF
--- a/ahk/__init__.py
+++ b/ahk/__init__.py
@@ -4,9 +4,21 @@ from typing import Optional
 from ._async import AsyncAHK
 from ._async import AsyncControl
 from ._async import AsyncWindow
+from ._async.transport import AsyncFutureResult
 from ._sync import AHK
 from ._sync import Control
 from ._sync import Window
+from ._sync.transport import FutureResult
+from ._types import Coordinates
+from ._types import CoordMode
+from ._types import CoordModeRelativeTo
+from ._types import CoordModeTargets
+from ._types import MatchModes
+from ._types import MatchSpeeds
+from ._types import MouseButton
+from ._types import Position
+from ._types import SendMode
+from ._types import TitleMatchMode
 from ._utils import MsgBoxButtons
 from ._utils import MsgBoxDefaultButton
 from ._utils import MsgBoxIcon
@@ -23,6 +35,22 @@ __all__ = [
     'MsgBoxDefaultButton',
     'MsgBoxIcon',
     'MsgBoxModality',
+    'Coordinates',
+    'CoordMode',
+    'CoordModeRelativeTo',
+    'CoordModeTargets',
+    'MatchModes',
+    'MatchSpeeds',
+    'MouseButton',
+    'Position',
+    'SendMode',
+    'TitleMatchMode',
+    'MsgBoxButtons',
+    'MsgBoxDefaultButton',
+    'MsgBoxIcon',
+    'MsgBoxModality',
+    'AsyncFutureResult',
+    'FutureResult',
 ]
 
 _global_instance: Optional[AHK[None]] = None

--- a/ahk/_async/engine.py
+++ b/ahk/_async/engine.py
@@ -52,9 +52,16 @@ from .transport import AsyncTransport
 from .window import AsyncControl
 from .window import AsyncWindow
 
-# from .window import AsyncGui
-from ahk.message import Position
-
+from ahk._types import (
+    Position,
+    CoordModeTargets,
+    CoordModeRelativeTo,
+    TitleMatchMode,
+    _BUTTONS,
+    MouseButton,
+    SendMode,
+    Coordinates,
+)
 
 async_sleep = asyncio.sleep  # unasync: remove
 sleep = time.sleep
@@ -62,57 +69,8 @@ sleep = time.sleep
 AsyncFilterFunc: TypeAlias = Callable[[AsyncWindow], Awaitable[bool]]  # unasync: remove
 SyncFilterFunc: TypeAlias = Callable[[AsyncWindow], bool]
 
-CoordModeTargets: TypeAlias = Union[
-    Literal['ToolTip'], Literal['Pixel'], Literal['Mouse'], Literal['Caret'], Literal['Menu']
-]
-CoordModeRelativeTo: TypeAlias = Union[Literal['Screen', 'Relative', 'Window', 'Client', '']]
-
-CoordMode: TypeAlias = Union[CoordModeTargets, Tuple[CoordModeTargets, CoordModeRelativeTo]]
-
-MatchModes: TypeAlias = Literal[1, 2, 3, 'RegEx', '']
-MatchSpeeds: TypeAlias = Literal['Fast', 'Slow', '']
-
-TitleMatchMode: TypeAlias = Optional[
-    Union[MatchModes, MatchSpeeds, Tuple[Union[MatchModes, MatchSpeeds], Union[MatchSpeeds, MatchModes]]]
-]
-
-_BUTTONS: dict[Union[str, int], str] = {
-    1: 'L',
-    2: 'R',
-    3: 'M',
-    'left': 'L',
-    'right': 'R',
-    'middle': 'M',
-    'wheelup': 'WU',
-    'wheeldown': 'WD',
-    'wheelleft': 'WL',
-    'wheelright': 'WR',
-}
-
-MouseButton: TypeAlias = Union[
-    int,
-    Literal[
-        'L',
-        'R',
-        'M',
-        'left',
-        'right',
-        'middle',
-        'wheelup',
-        'WU',
-        'wheeldown',
-        'WD',
-        'wheelleft',
-        'WL',
-        'wheelright',
-        'WR',
-    ],
-]
-
-SendMode: TypeAlias = Literal['Event', 'Input', 'InputThenPlay', 'Play', '']
-
-AsyncPropertyReturnTupleIntInt: TypeAlias = Coroutine[None, None, Tuple[int, int]]  # unasync: remove
-SyncPropertyReturnTupleIntInt: TypeAlias = Tuple[int, int]
+AsyncPropertyReturnTupleIntInt: TypeAlias = Coroutine[None, None, Coordinates]  # unasync: remove
+SyncPropertyReturnTupleIntInt: TypeAlias = Coordinates
 
 AsyncPropertyReturnOptionalAsyncWindow: TypeAlias = Coroutine[None, None, Optional[AsyncWindow]]  # unasync: remove
 SyncPropertyReturnOptionalAsyncWindow: TypeAlias = Optional[AsyncWindow]
@@ -737,17 +695,17 @@ class AsyncAHK(Generic[T_AHKVersion]):
 
     # fmt: off
     @overload
-    async def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: Literal[True]) -> Tuple[int, int]: ...
+    async def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: Literal[True]) -> Coordinates: ...
     @overload
-    async def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: Literal[False]) -> AsyncFutureResult[Tuple[int, int]]: ...
+    async def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: Literal[False]) -> AsyncFutureResult[Coordinates]: ...
     @overload
-    async def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None) -> Tuple[int, int]: ...
+    async def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None) -> Coordinates: ...
     @overload
-    async def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: bool = True) -> Union[Tuple[int, int], AsyncFutureResult[Tuple[int, int]]]: ...
+    async def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: bool = True) -> Union[Coordinates, AsyncFutureResult[Coordinates]]: ...
     # fmt: on
     async def get_mouse_position(
         self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: bool = True
-    ) -> Union[Tuple[int, int], AsyncFutureResult[Tuple[int, int]]]:
+    ) -> Union[Coordinates, AsyncFutureResult[Coordinates]]:
         """
         Analog for `MouseGetPos <https://www.autohotkey.com/docs/commands/MouseGetPos.htm>`_
         """
@@ -2870,13 +2828,13 @@ class AsyncAHK(Generic[T_AHKVersion]):
 
     # fmt: off
     @overload
-    async def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None) -> Optional[Tuple[int, int]]: ...
+    async def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None) -> Optional[Coordinates]: ...
     @overload
-    async def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None, blocking: Literal[False]) -> AsyncFutureResult[Optional[Tuple[int, int]]]: ...
+    async def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None, blocking: Literal[False]) -> AsyncFutureResult[Optional[Coordinates]]: ...
     @overload
-    async def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None, blocking: Literal[True]) -> Optional[Tuple[int, int]]: ...
+    async def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None, blocking: Literal[True]) -> Optional[Coordinates]: ...
     @overload
-    async def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None, blocking: bool = True) -> Union[Tuple[int, int], None, AsyncFutureResult[Optional[Tuple[int, int]]]]: ...
+    async def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None, blocking: bool = True) -> Union[Coordinates, None, AsyncFutureResult[Optional[Coordinates]]]: ...
     # fmt: on
     async def image_search(
         self,
@@ -2891,7 +2849,7 @@ class AsyncAHK(Generic[T_AHKVersion]):
         transparent: Optional[str] = None,
         icon: Optional[int] = None,
         blocking: bool = True,
-    ) -> Union[Tuple[int, int], None, AsyncFutureResult[Optional[Tuple[int, int]]]]:
+    ) -> Union[Coordinates, None, AsyncFutureResult[Optional[Coordinates]]]:
         """
         Analog for `ImageSearch <https://www.autohotkey.com/docs/commands/ImageSearch.htm>`_
         """
@@ -3026,13 +2984,13 @@ class AsyncAHK(Generic[T_AHKVersion]):
 
     # fmt: off
     @overload
-    async def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True) -> Optional[Tuple[int, int]]: ...
+    async def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True) -> Optional[Coordinates]: ...
     @overload
-    async def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True, blocking: Literal[True]) -> Optional[Tuple[int, int]]: ...
+    async def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True, blocking: Literal[True]) -> Optional[Coordinates]: ...
     @overload
-    async def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True, blocking: Literal[False]) -> AsyncFutureResult[Optional[Tuple[int, int]]]: ...
+    async def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True, blocking: Literal[False]) -> AsyncFutureResult[Optional[Coordinates]]: ...
     @overload
-    async def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True, blocking: bool = True) -> Union[Optional[Tuple[int, int]], AsyncFutureResult[Optional[Tuple[int, int]]]]: ...
+    async def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True, blocking: bool = True) -> Union[Optional[Coordinates], AsyncFutureResult[Optional[Coordinates]]]: ...
     # fmt: on
     async def pixel_search(
         self,
@@ -3045,7 +3003,7 @@ class AsyncAHK(Generic[T_AHKVersion]):
         fast: bool = True,
         rgb: bool = True,
         blocking: bool = True,
-    ) -> Union[Optional[Tuple[int, int]], AsyncFutureResult[Optional[Tuple[int, int]]]]:
+    ) -> Union[Optional[Coordinates], AsyncFutureResult[Optional[Coordinates]]]:
         """
         Analog for `PixelSearch <https://www.autohotkey.com/docs/commands/PixelSearch.htm>`_
         """

--- a/ahk/_async/transport.py
+++ b/ahk/_async/transport.py
@@ -11,6 +11,8 @@ import threading
 import warnings
 from abc import ABC
 from abc import abstractmethod
+from concurrent.futures import Future
+from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from typing import Any
 from typing import Callable
@@ -27,6 +29,26 @@ from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
+import jinja2
+
+from ahk._constants import DAEMON_SCRIPT_TEMPLATE as _DAEMON_SCRIPT_TEMPLATE
+from ahk._constants import DAEMON_SCRIPT_V2_TEMPLATE as _DAEMON_SCRIPT_V2_TEMPLATE
+from ahk._hotkey import Hotkey
+from ahk._hotkey import Hotstring
+from ahk._hotkey import ThreadedHotkeyTransport
+from ahk._types import Coordinates
+from ahk._types import FunctionName
+from ahk._types import Position
+from ahk._utils import _version_detection_script
+from ahk.directives import Directive
+from ahk.exceptions import AHKProtocolError
+from ahk.extensions import _resolve_includes
+from ahk.extensions import Extension
+from ahk.message import _message_registry
+from ahk.message import RequestMessage
+from ahk.message import ResponseMessage
+
+
 if TYPE_CHECKING:
     from ahk import AsyncControl
     from ahk import AsyncWindow
@@ -35,24 +57,6 @@ if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias, TypeGuard
 else:
     from typing import TypeAlias, TypeGuard
-
-import jinja2
-
-from ahk.extensions import Extension, _resolve_includes
-from ahk._hotkey import ThreadedHotkeyTransport, Hotkey, Hotstring
-from ahk.message import RequestMessage
-from ahk.message import ResponseMessage
-from ahk.message import Position
-from ahk.message import _message_registry
-from ahk._constants import (
-    DAEMON_SCRIPT_TEMPLATE as _DAEMON_SCRIPT_TEMPLATE,
-    DAEMON_SCRIPT_V2_TEMPLATE as _DAEMON_SCRIPT_V2_TEMPLATE,
-)
-from ahk._utils import _version_detection_script
-from ahk.directives import Directive
-from ahk.exceptions import AHKProtocolError
-
-from concurrent.futures import Future, ThreadPoolExecutor
 
 
 T_AsyncFuture = TypeVar('T_AsyncFuture')  # unasync: remove
@@ -80,115 +84,6 @@ AsyncIOProcess: TypeAlias = asyncio.subprocess.Process  # unasync: remove
 SyncIOProcess: TypeAlias = 'subprocess.Popen[bytes]'
 
 
-FunctionName = Literal[
-    'AHKBlockInput',
-    'AHKClipWait',
-    'AHKControlClick',
-    'AHKControlGetPos',
-    'AHKControlGetText',
-    'AHKControlSend',
-    'AHKFileSelectFile',
-    'AHKFileSelectFolder',
-    'AHKGetClipboard',
-    'AHKGetClipboardAll',
-    'AHKGetCoordMode',
-    'AHKGetSendLevel',
-    'AHKGetSendMode',
-    'AHKGetTitleMatchMode',
-    'AHKGetTitleMatchSpeed',
-    'AHKGetVolume',
-    'AHKGuiNew',
-    'AHKImageSearch',
-    'AHKInputBox',
-    'AHKKeyState',
-    'AHKKeyWait',
-    'AHKMenuTrayIcon',
-    'AHKMenuTrayShow',
-    'AHKMenuTrayHide',
-    'AHKMenuTrayTip',
-    'AHKMsgBox',
-    'AHKMouseClickDrag',
-    'AHKMouseGetPos',
-    'AHKMouseMove',
-    'AHKPixelGetColor',
-    'AHKPixelSearch',
-    'AHKRegRead',
-    'AHKRegWrite',
-    'AHKRegDelete',
-    'AHKSend',
-    'AHKSendEvent',
-    'AHKSendInput',
-    'AHKSendPlay',
-    'AHKSendRaw',
-    'AHKSetClipboard',
-    'AHKSetClipboardAll',
-    'AHKSetCoordMode',
-    'AHKSetDetectHiddenWindows',
-    'AHKSetSendLevel',
-    'AHKSetSendMode',
-    'AHKSetTitleMatchMode',
-    'AHKSetVolume',
-    'AHKShowToolTip',
-    'AHKSoundBeep',
-    'AHKSoundGet',
-    'AHKSoundPlay',
-    'AHKSoundSet',
-    'AHKTrayTip',
-    'AHKWinActivate',
-    'AHKWinClose',
-    'AHKWinExist',
-    'AHKWinFromMouse',
-    'AHKWinGetControlList',
-    'AHKWinGetControlListHwnd',
-    'AHKWinGetCount',
-    'AHKWinGetExStyle',
-    'AHKWinGetID',
-    'AHKWinGetIDLast',
-    'AHKWinGetList',
-    'AHKWinGetMinMax',
-    'AHKWinGetPID',
-    'AHKWinGetPos',
-    'AHKWinGetProcessName',
-    'AHKWinGetProcessPath',
-    'AHKWinGetStyle',
-    'AHKWinGetText',
-    'AHKWinGetTitle',
-    'AHKWinGetTransColor',
-    'AHKWinGetTransparent',
-    'AHKWinHide',
-    'AHKWinIsActive',
-    'AHKWinIsAlwaysOnTop',
-    'AHKWinMove',
-    'AHKWinSetAlwaysOnTop',
-    'AHKWinSetBottom',
-    'AHKWinSetDisable',
-    'AHKWinSetEnable',
-    'AHKWinSetExStyle',
-    'AHKWinSetRedraw',
-    'AHKWinSetRegion',
-    'AHKWinSetStyle',
-    'AHKWinSetTitle',
-    'AHKWinSetTop',
-    'AHKWinSetTransColor',
-    'AHKWinSetTransparent',
-    'AHKWinShow',
-    'AHKWindowList',
-    'AHKWinWait',
-    'AHKWinWaitActive',
-    'AHKWinWaitClose',
-    'AHKWinWaitNotActive',
-    'AHKClick',
-    'AHKSetCapsLockState',
-    'SetKeyDelay',
-    'WinActivateBottom',
-    'AHKWinGetClass',
-    'AHKWinKill',
-    'AHKWinMaximize',
-    'AHKWinMinimize',
-    'AHKWinRestore',
-]
-
-
 @runtime_checkable
 class Killable(Protocol):
     def kill(self) -> None: ...
@@ -204,7 +99,9 @@ def kill(proc: Killable) -> None:
 def async_assert_send_nonblocking_type_correct(
     obj: Any,
 ) -> TypeGuard[
-    Future[Union[None, Tuple[int, int], int, str, bool, AsyncWindow, List[AsyncWindow], List[AsyncControl]]]
+    Future[
+        Union[None, Coordinates, Tuple[int, int], int, str, bool, AsyncWindow, List[AsyncWindow], List[AsyncControl]]
+    ]
 ]:
     return True
 
@@ -407,13 +304,13 @@ class AsyncTransport(ABC):
     @overload
     async def function_call(self, function_name: Literal['AHKWinExist'], args: Optional[List[str]] = None, *, blocking: bool = True, engine: Optional[AsyncAHK[Any]] = None) -> Union[bool, AsyncFutureResult[bool]]: ...
     @overload
-    async def function_call(self, function_name: Literal['AHKImageSearch'], args: Optional[List[str]] = None, *, blocking: bool = True, engine: Optional[AsyncAHK[Any]] = None) -> Union[Tuple[int, int], None, AsyncFutureResult[Union[Tuple[int, int], None]]]: ...
+    async def function_call(self, function_name: Literal['AHKImageSearch'], args: Optional[List[str]] = None, *, blocking: bool = True, engine: Optional[AsyncAHK[Any]] = None) -> Union[Coordinates, None, AsyncFutureResult[Union[Coordinates, None]]]: ...
     @overload
     async def function_call(self, function_name: Literal['AHKPixelGetColor'], args: Optional[List[str]] = None, *, blocking: bool = True, engine: Optional[AsyncAHK[Any]] = None) -> Union[str, AsyncFutureResult[str]]: ...
     @overload
-    async def function_call(self, function_name: Literal['AHKPixelSearch'], args: Optional[List[str]] = None, *, blocking: bool = True, engine: Optional[AsyncAHK[Any]] = None) -> Union[Optional[Tuple[int, int]], AsyncFutureResult[Optional[Tuple[int, int]]]]: ...
+    async def function_call(self, function_name: Literal['AHKPixelSearch'], args: Optional[List[str]] = None, *, blocking: bool = True, engine: Optional[AsyncAHK[Any]] = None) -> Union[Optional[Coordinates], AsyncFutureResult[Optional[Coordinates]]]: ...
     @overload
-    async def function_call(self, function_name: Literal['AHKMouseGetPos'], args: Optional[List[str]] = None, *, blocking: bool = True, engine: Optional[AsyncAHK[Any]] = None) -> Union[Tuple[int, int], AsyncFutureResult[Tuple[int, int]]]: ...
+    async def function_call(self, function_name: Literal['AHKMouseGetPos'], args: Optional[List[str]] = None, *, blocking: bool = True, engine: Optional[AsyncAHK[Any]] = None) -> Union[Coordinates, AsyncFutureResult[Coordinates]]: ...
     @overload
     async def function_call(self, function_name: Literal['AHKKeyState'], args: Optional[List[str]] = None, *, blocking: bool = True, engine: Optional[AsyncAHK[Any]] = None) -> Union[int, float, str, None, AsyncFutureResult[None], AsyncFutureResult[str], AsyncFutureResult[int], AsyncFutureResult[float]]: ...
     @overload

--- a/ahk/_async/window.py
+++ b/ahk/_async/window.py
@@ -14,8 +14,8 @@ from typing import TypedDict
 from typing import TypeVar
 from typing import Union
 
+from ahk._types import Position
 from ahk.exceptions import WindowNotFoundException
-from ahk.message import Position
 
 if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias

--- a/ahk/_sync/engine.py
+++ b/ahk/_sync/engine.py
@@ -52,64 +52,13 @@ from .transport import Transport
 from .window import Control
 from .window import Window
 
-# from .window import AsyncGui
-from ahk.message import Position
-
+from ahk._types import Position, CoordModeTargets, CoordModeRelativeTo, TitleMatchMode, _BUTTONS, MouseButton, SendMode, Coordinates
 
 sleep = time.sleep
 
 SyncFilterFunc: TypeAlias = Callable[[Window], bool]
 
-CoordModeTargets: TypeAlias = Union[
-    Literal['ToolTip'], Literal['Pixel'], Literal['Mouse'], Literal['Caret'], Literal['Menu']
-]
-CoordModeRelativeTo: TypeAlias = Union[Literal['Screen', 'Relative', 'Window', 'Client', '']]
-
-CoordMode: TypeAlias = Union[CoordModeTargets, Tuple[CoordModeTargets, CoordModeRelativeTo]]
-
-MatchModes: TypeAlias = Literal[1, 2, 3, 'RegEx', '']
-MatchSpeeds: TypeAlias = Literal['Fast', 'Slow', '']
-
-TitleMatchMode: TypeAlias = Optional[
-    Union[MatchModes, MatchSpeeds, Tuple[Union[MatchModes, MatchSpeeds], Union[MatchSpeeds, MatchModes]]]
-]
-
-_BUTTONS: dict[Union[str, int], str] = {
-    1: 'L',
-    2: 'R',
-    3: 'M',
-    'left': 'L',
-    'right': 'R',
-    'middle': 'M',
-    'wheelup': 'WU',
-    'wheeldown': 'WD',
-    'wheelleft': 'WL',
-    'wheelright': 'WR',
-}
-
-MouseButton: TypeAlias = Union[
-    int,
-    Literal[
-        'L',
-        'R',
-        'M',
-        'left',
-        'right',
-        'middle',
-        'wheelup',
-        'WU',
-        'wheeldown',
-        'WD',
-        'wheelleft',
-        'WL',
-        'wheelright',
-        'WR',
-    ],
-]
-
-SendMode: TypeAlias = Literal['Event', 'Input', 'InputThenPlay', 'Play', '']
-
-SyncPropertyReturnTupleIntInt: TypeAlias = Tuple[int, int]
+SyncPropertyReturnTupleIntInt: TypeAlias = Coordinates
 
 SyncPropertyReturnOptionalAsyncWindow: TypeAlias = Optional[Window]
 
@@ -732,17 +681,17 @@ class AHK(Generic[T_AHKVersion]):
 
     # fmt: off
     @overload
-    def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: Literal[True]) -> Tuple[int, int]: ...
+    def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: Literal[True]) -> Coordinates: ...
     @overload
-    def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: Literal[False]) -> FutureResult[Tuple[int, int]]: ...
+    def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: Literal[False]) -> FutureResult[Coordinates]: ...
     @overload
-    def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None) -> Tuple[int, int]: ...
+    def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None) -> Coordinates: ...
     @overload
-    def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: bool = True) -> Union[Tuple[int, int], FutureResult[Tuple[int, int]]]: ...
+    def get_mouse_position(self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: bool = True) -> Union[Coordinates, FutureResult[Coordinates]]: ...
     # fmt: on
     def get_mouse_position(
         self, coord_mode: Optional[CoordModeRelativeTo] = None, *, blocking: bool = True
-    ) -> Union[Tuple[int, int], FutureResult[Tuple[int, int]]]:
+    ) -> Union[Coordinates, FutureResult[Coordinates]]:
         """
         Analog for `MouseGetPos <https://www.autohotkey.com/docs/commands/MouseGetPos.htm>`_
         """
@@ -2858,13 +2807,13 @@ class AHK(Generic[T_AHKVersion]):
 
     # fmt: off
     @overload
-    def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None) -> Optional[Tuple[int, int]]: ...
+    def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None) -> Optional[Coordinates]: ...
     @overload
-    def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None, blocking: Literal[False]) -> FutureResult[Optional[Tuple[int, int]]]: ...
+    def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None, blocking: Literal[False]) -> FutureResult[Optional[Coordinates]]: ...
     @overload
-    def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None, blocking: Literal[True]) -> Optional[Tuple[int, int]]: ...
+    def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None, blocking: Literal[True]) -> Optional[Coordinates]: ...
     @overload
-    def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None, blocking: bool = True) -> Union[Tuple[int, int], None, FutureResult[Optional[Tuple[int, int]]]]: ...
+    def image_search(self, image_path: str, upper_bound: Tuple[Union[int, str], Union[int, str]] = (0, 0), lower_bound: Optional[Tuple[Union[int, str], Union[int, str]]] = None, *, color_variation: Optional[int] = None, coord_mode: Optional[CoordModeRelativeTo] = None, scale_height: Optional[int] = None, scale_width: Optional[int] = None, transparent: Optional[str] = None, icon: Optional[int] = None, blocking: bool = True) -> Union[Coordinates, None, FutureResult[Optional[Coordinates]]]: ...
     # fmt: on
     def image_search(
         self,
@@ -2879,7 +2828,7 @@ class AHK(Generic[T_AHKVersion]):
         transparent: Optional[str] = None,
         icon: Optional[int] = None,
         blocking: bool = True,
-    ) -> Union[Tuple[int, int], None, FutureResult[Optional[Tuple[int, int]]]]:
+    ) -> Union[Coordinates, None, FutureResult[Optional[Coordinates]]]:
         """
         Analog for `ImageSearch <https://www.autohotkey.com/docs/commands/ImageSearch.htm>`_
         """
@@ -3014,13 +2963,13 @@ class AHK(Generic[T_AHKVersion]):
 
     # fmt: off
     @overload
-    def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True) -> Optional[Tuple[int, int]]: ...
+    def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True) -> Optional[Coordinates]: ...
     @overload
-    def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True, blocking: Literal[True]) -> Optional[Tuple[int, int]]: ...
+    def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True, blocking: Literal[True]) -> Optional[Coordinates]: ...
     @overload
-    def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True, blocking: Literal[False]) -> FutureResult[Optional[Tuple[int, int]]]: ...
+    def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True, blocking: Literal[False]) -> FutureResult[Optional[Coordinates]]: ...
     @overload
-    def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True, blocking: bool = True) -> Union[Optional[Tuple[int, int]], FutureResult[Optional[Tuple[int, int]]]]: ...
+    def pixel_search(self, search_region_start: Tuple[int, int], search_region_end: Tuple[int, int], color: Union[str, int], variation: int = 0, *, coord_mode: Optional[CoordModeRelativeTo] = None, fast: bool = True, rgb: bool = True, blocking: bool = True) -> Union[Optional[Coordinates], FutureResult[Optional[Coordinates]]]: ...
     # fmt: on
     def pixel_search(
         self,
@@ -3033,7 +2982,7 @@ class AHK(Generic[T_AHKVersion]):
         fast: bool = True,
         rgb: bool = True,
         blocking: bool = True,
-    ) -> Union[Optional[Tuple[int, int]], FutureResult[Optional[Tuple[int, int]]]]:
+    ) -> Union[Optional[Coordinates], FutureResult[Optional[Coordinates]]]:
         """
         Analog for `PixelSearch <https://www.autohotkey.com/docs/commands/PixelSearch.htm>`_
         """

--- a/ahk/_sync/window.py
+++ b/ahk/_sync/window.py
@@ -14,8 +14,8 @@ from typing import TypedDict
 from typing import TypeVar
 from typing import Union
 
+from ahk._types import Position
 from ahk.exceptions import WindowNotFoundException
-from ahk.message import Position
 
 if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias
@@ -30,8 +30,6 @@ else:
 if TYPE_CHECKING:
     from .engine import AHK
     from .transport import FutureResult
-
-
 
 
 SyncPropertyReturnStr: TypeAlias = str

--- a/ahk/_types.py
+++ b/ahk/_types.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import sys
+from typing import Literal
+from typing import NamedTuple
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias
+
+
+class Position(NamedTuple):
+    x: int
+    y: int
+    width: int
+    height: int
+
+
+class Coordinates(NamedTuple):
+    x: int
+    y: int
+
+
+CoordModeTargets: TypeAlias = Union[
+    Literal['ToolTip'], Literal['Pixel'], Literal['Mouse'], Literal['Caret'], Literal['Menu']
+]
+CoordModeRelativeTo: TypeAlias = Union[Literal['Screen', 'Relative', 'Window', 'Client', '']]
+
+CoordMode: TypeAlias = Union[CoordModeTargets, Tuple[CoordModeTargets, CoordModeRelativeTo]]
+
+MatchModes: TypeAlias = Literal[1, 2, 3, 'RegEx', '']
+MatchSpeeds: TypeAlias = Literal['Fast', 'Slow', '']
+
+TitleMatchMode: TypeAlias = Optional[
+    Union[MatchModes, MatchSpeeds, Tuple[Union[MatchModes, MatchSpeeds], Union[MatchSpeeds, MatchModes]]]
+]
+
+_BUTTONS: dict[Union[str, int], str] = {
+    1: 'L',
+    2: 'R',
+    3: 'M',
+    'left': 'L',
+    'right': 'R',
+    'middle': 'M',
+    'wheelup': 'WU',
+    'wheeldown': 'WD',
+    'wheelleft': 'WL',
+    'wheelright': 'WR',
+}
+
+MouseButton: TypeAlias = Union[
+    int,
+    Literal[
+        'L',
+        'R',
+        'M',
+        'left',
+        'right',
+        'middle',
+        'wheelup',
+        'WU',
+        'wheeldown',
+        'WD',
+        'wheelleft',
+        'WL',
+        'wheelright',
+        'WR',
+    ],
+]
+
+SendMode: TypeAlias = Literal['Event', 'Input', 'InputThenPlay', 'Play', '']
+
+FunctionName = Literal[
+    'AHKBlockInput',
+    'AHKClipWait',
+    'AHKControlClick',
+    'AHKControlGetPos',
+    'AHKControlGetText',
+    'AHKControlSend',
+    'AHKFileSelectFile',
+    'AHKFileSelectFolder',
+    'AHKGetClipboard',
+    'AHKGetClipboardAll',
+    'AHKGetCoordMode',
+    'AHKGetSendLevel',
+    'AHKGetSendMode',
+    'AHKGetTitleMatchMode',
+    'AHKGetTitleMatchSpeed',
+    'AHKGetVolume',
+    'AHKGuiNew',
+    'AHKImageSearch',
+    'AHKInputBox',
+    'AHKKeyState',
+    'AHKKeyWait',
+    'AHKMenuTrayIcon',
+    'AHKMenuTrayShow',
+    'AHKMenuTrayHide',
+    'AHKMenuTrayTip',
+    'AHKMsgBox',
+    'AHKMouseClickDrag',
+    'AHKMouseGetPos',
+    'AHKMouseMove',
+    'AHKPixelGetColor',
+    'AHKPixelSearch',
+    'AHKRegRead',
+    'AHKRegWrite',
+    'AHKRegDelete',
+    'AHKSend',
+    'AHKSendEvent',
+    'AHKSendInput',
+    'AHKSendPlay',
+    'AHKSendRaw',
+    'AHKSetClipboard',
+    'AHKSetClipboardAll',
+    'AHKSetCoordMode',
+    'AHKSetDetectHiddenWindows',
+    'AHKSetSendLevel',
+    'AHKSetSendMode',
+    'AHKSetTitleMatchMode',
+    'AHKSetVolume',
+    'AHKShowToolTip',
+    'AHKSoundBeep',
+    'AHKSoundGet',
+    'AHKSoundPlay',
+    'AHKSoundSet',
+    'AHKTrayTip',
+    'AHKWinActivate',
+    'AHKWinClose',
+    'AHKWinExist',
+    'AHKWinFromMouse',
+    'AHKWinGetControlList',
+    'AHKWinGetControlListHwnd',
+    'AHKWinGetCount',
+    'AHKWinGetExStyle',
+    'AHKWinGetID',
+    'AHKWinGetIDLast',
+    'AHKWinGetList',
+    'AHKWinGetMinMax',
+    'AHKWinGetPID',
+    'AHKWinGetPos',
+    'AHKWinGetProcessName',
+    'AHKWinGetProcessPath',
+    'AHKWinGetStyle',
+    'AHKWinGetText',
+    'AHKWinGetTitle',
+    'AHKWinGetTransColor',
+    'AHKWinGetTransparent',
+    'AHKWinHide',
+    'AHKWinIsActive',
+    'AHKWinIsAlwaysOnTop',
+    'AHKWinMove',
+    'AHKWinSetAlwaysOnTop',
+    'AHKWinSetBottom',
+    'AHKWinSetDisable',
+    'AHKWinSetEnable',
+    'AHKWinSetExStyle',
+    'AHKWinSetRedraw',
+    'AHKWinSetRegion',
+    'AHKWinSetStyle',
+    'AHKWinSetTitle',
+    'AHKWinSetTop',
+    'AHKWinSetTransColor',
+    'AHKWinSetTransparent',
+    'AHKWinShow',
+    'AHKWindowList',
+    'AHKWinWait',
+    'AHKWinWaitActive',
+    'AHKWinWaitClose',
+    'AHKWinWaitNotActive',
+    'AHKClick',
+    'AHKSetCapsLockState',
+    'SetKeyDelay',
+    'WinActivateBottom',
+    'AHKWinGetClass',
+    'AHKWinKill',
+    'AHKWinMaximize',
+    'AHKWinMinimize',
+    'AHKWinRestore',
+]

--- a/ahk/message.py
+++ b/ahk/message.py
@@ -7,7 +7,6 @@ import string
 import sys
 from abc import abstractmethod
 from base64 import b64encode
-from collections import namedtuple
 from typing import Any
 from typing import cast
 from typing import Generator
@@ -28,12 +27,10 @@ from typing import TypeVar
 from typing import Union
 
 from ahk.exceptions import AHKExecutionException
+from ahk._types import Position, Coordinates
 
 
 class OutOfMessageTypes(Exception): ...
-
-
-Position = namedtuple('Position', ('x', 'y', 'width', 'height'))
 
 
 @runtime_checkable
@@ -157,12 +154,12 @@ class TupleResponseMessage(ResponseMessage):
 
 
 class CoordinateResponseMessage(ResponseMessage):
-    def unpack(self) -> Tuple[int, int]:
+    def unpack(self) -> Coordinates:
         s = self._raw_content.decode(encoding='utf-8')
         val = ast.literal_eval(s)
         assert isinstance(val, tuple)
         x, y = cast(Tuple[int, int], val)
-        return x, y
+        return Coordinates(x, y)
 
 
 class IntegerResponseMessage(ResponseMessage):


### PR DESCRIPTION
- `mouse_position`, `get_mouse_position`, `pixel_search`, and `image_search` now return a `Coordinates` named tuple (`typing.NamedTuple`) type instead of just a plain `tuple[int, int]`.
- Refactored types shared between sync and async into a common, internal, `_types` module.
- The `Position` type is now created using `typing.NamedTuple` rather than `collections.namedtuple`.
- Exposes more types directly via `__init__.py` so they can be imported without reaching into internal modules.