### PR TITLE
Executor tray tip

### DIFF
--- a/ahk/directives.py
+++ b/ahk/directives.py
@@ -159,19 +159,17 @@ class WinActivateForce(Directive):
 
 class TrayTip(Directive):
     def __init__(self, text: str, **kwargs: Any):
-        self.text: str = (text or '').replace('\n', ' ')
+        if not isinstance(text, str):
+            raise TypeError('Parameter "text" must be a string.')
+
+        self.text: str = text.replace('"', '').replace('\n', ' ')
 
         super().__init__(**kwargs)
 
     def __str__(self) -> str:
-        if self.text:
-            return f'A_IconTip := "{self.text}"'
-        return ''
+        return f'A_IconTip := "{self.text}"'
 
 
 class ExecutorTrayTip(TrayTip):
     def __init__(self, text: str, **kwargs: Any):
-        self.text: str = (text or '').replace('\n', ' ')
-
-        kwargs['apply_to_hotkeys_process'] = True
-        super().__init__(text=text, **kwargs)
+        super().__init__(text=text, **kwargs, apply_to_hotkeys_process=True)

--- a/ahk/directives.py
+++ b/ahk/directives.py
@@ -155,3 +155,23 @@ class Warn(Directive):
 
 class WinActivateForce(Directive):
     pass
+
+
+class TrayTip(Directive):
+    def __init__(self, text: str, **kwargs: Any):
+        self.text: str = (text or '').replace('\n', ' ')
+
+        super().__init__(**kwargs)
+
+    def __str__(self) -> str:
+        if self.text:
+            return f'A_IconTip := "{self.text}"'
+        return ''
+
+
+class ExecutorTrayTip(TrayTip):
+    def __init__(self, text: str, **kwargs: Any):
+        self.text: str = (text or '').replace('\n', ' ')
+
+        kwargs['apply_to_hotkeys_process'] = True
+        super().__init__(text=text, **kwargs)


### PR DESCRIPTION
Hello! Sorry if i got something wrong and for long post. But i stumbled on issue (for me at least).

My goal was just run script and change AHK tray icon tip (from `executor.ahk` to anything else). I read about `menu_tray_tooltip` method and used it. But instead of just changing tip i got two tray icons! one of these was with text stated by me and another one was initial icon with tip `executor.ahk`.

Then i tried `menu_tray_icon_hide` method, and it's hide icon with my text and leave only one with text `executor.ahk`. So it's seems what use both `menu_tray_tooltip` and `menu_tray_icon_hide` makes no sense.

Ok. Moving on. After that i tried `menu_tray_tooltip` with `NoTrayIcon(apply_to_hotkeys_process=True)` directive.
So i got one icon with my text. Almost win. But there is one problem.
That icon hasn't menu like initial icon with tip `executor.ahk` has.
But i want to keep that menu.

And looks like to achieve that it must be changed tip of exactly that icon with `executor.ahk` text.

So i wrote new directive for that. And create this pull request to share it with all.

Example of usage:

```python
from ahk.directives import TrayTip, ExecutorTrayTip

ahk = AHK(directives=[TrayTip('hello!', apply_to_hotkeys_process=True)], version='v2')

# or even simpler
ahk = AHK(directives=[ExecutorTrayTip('hello!')], version='v2')

# also as side effect it's possible to remove tip at all if state an empty string
ahk = AHK(directives=[ExecutorTrayTip('')], version='v2')
```