### PR TITLE
fix bug where `black.assert_equivalent` no longer raises an AssertionError

### DIFF
--- a/.unasync-rewrite.py
+++ b/.unasync-rewrite.py
@@ -9,6 +9,11 @@ GIT_EXECUTABLE = shutil.which('git')
 
 changes = 0
 
+if hasattr(black, 'ASTSafetyError'):
+    exceptions = (AssertionError, black.ASTSafetyError)
+else:
+    exceptions = (AssertionError,)
+
 
 def _copyfunc(src, dst, *, follow_symlinks=True):
     global changes
@@ -22,7 +27,7 @@ def _copyfunc(src, dst, *, follow_symlinks=True):
                 src=contents,
                 dst=dst_contents,
             )
-        except AssertionError:
+        except exceptions:
             changes += 1
             print('MODIFIED', dst)
             shutil.copy2(src, dst, follow_symlinks=follow_symlinks)


### PR DESCRIPTION
https://github.com/psf/black/pull/4270 changed `black.assert_equivalent` to raise an `ASTSafetyError` exception (a custom exception inheriting from `Exception`) so catching `AssertionError` no longer works when developing with recent versions of `black`

This change makes the code compatible with older and newer versions of `black`.