### PR TITLE
GH-315 fix usage of SetKeyDelay in AHKv2

### DIFF
--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -5054,7 +5054,13 @@ AHKSend(args*) {
     }
 
     if (key_delay != "" or key_press_duration != "") {
-        SetKeyDelay(key_delay, key_press_duration)
+        if (key_delay != "" and key_press_duration != "") {
+            SetKeyDelay(key_delay, key_press_duration)
+        } else if (key_delay != "" and key_press_duration = "") {
+            SetKeyDelay(key_delay)
+        } else if (key_delay = "" and key_press_duration != "") {
+            SetKeyDelay(current_delay, key_press_duration)
+        }
     }
 
 
@@ -5080,7 +5086,13 @@ AHKSendRaw(args*) {
     current_key_duration := Format("{}", A_KeyDuration)
 
     if (key_delay != "" or key_press_duration != "") {
-        SetKeyDelay(key_delay, key_press_duration)
+        if (key_delay != "" and key_press_duration != "") {
+            SetKeyDelay(key_delay, key_press_duration)
+        } else if (key_delay != "" and key_press_duration = "") {
+            SetKeyDelay(key_delay)
+        } else if (key_delay = "" and key_press_duration != "") {
+            SetKeyDelay(current_delay, key_press_duration)
+        }
     }
 
     Send("{Raw}" str)
@@ -5101,7 +5113,13 @@ AHKSendInput(args*) {
     current_key_duration := Format("{}", A_KeyDuration)
 
     if (key_delay != "" or key_press_duration != "") {
-        SetKeyDelay(key_delay, key_press_duration)
+        if (key_delay != "" and key_press_duration != "") {
+            SetKeyDelay(key_delay, key_press_duration)
+        } else if (key_delay != "" and key_press_duration = "") {
+            SetKeyDelay(key_delay)
+        } else if (key_delay = "" and key_press_duration != "") {
+            SetKeyDelay(current_delay, key_press_duration)
+        }
     }
 
     SendInput(str)
@@ -5122,7 +5140,13 @@ AHKSendEvent(args*) {
     current_key_duration := Format("{}", A_KeyDuration)
 
     if (key_delay != "" or key_press_duration != "") {
-        SetKeyDelay(key_delay, key_press_duration)
+        if (key_delay != "" and key_press_duration != "") {
+            SetKeyDelay(key_delay, key_press_duration)
+        } else if (key_delay != "" and key_press_duration = "") {
+            SetKeyDelay(key_delay)
+        } else if (key_delay = "" and key_press_duration != "") {
+            SetKeyDelay(current_delay, key_press_duration)
+        }
     }
 
     SendEvent(str)
@@ -5143,7 +5167,13 @@ AHKSendPlay(args*) {
     current_key_duration := Format("{}", A_KeyDurationPlay)
 
     if (key_delay != "" or key_press_duration != "") {
-        SetKeyDelay(key_delay, key_press_duration, "Play")
+        if (key_delay != "" and key_press_duration != "") {
+            SetKeyDelay(key_delay, key_press_duration)
+        } else if (key_delay != "" and key_press_duration = "") {
+            SetKeyDelay(key_delay)
+        } else if (key_delay = "" and key_press_duration != "") {
+            SetKeyDelay(current_delay, key_press_duration)
+        }
     }
 
     SendPlay(str)

--- a/ahk/templates/daemon-v2.ahk
+++ b/ahk/templates/daemon-v2.ahk
@@ -2041,7 +2041,13 @@ AHKSend(args*) {
     }
 
     if (key_delay != "" or key_press_duration != "") {
-        SetKeyDelay(key_delay, key_press_duration)
+        if (key_delay != "" and key_press_duration != "") {
+            SetKeyDelay(key_delay, key_press_duration)
+        } else if (key_delay != "" and key_press_duration = "") {
+            SetKeyDelay(key_delay)
+        } else if (key_delay = "" and key_press_duration != "") {
+            SetKeyDelay(current_delay, key_press_duration)
+        }
     }
 
 
@@ -2067,7 +2073,13 @@ AHKSendRaw(args*) {
     current_key_duration := Format("{}", A_KeyDuration)
 
     if (key_delay != "" or key_press_duration != "") {
-        SetKeyDelay(key_delay, key_press_duration)
+        if (key_delay != "" and key_press_duration != "") {
+            SetKeyDelay(key_delay, key_press_duration)
+        } else if (key_delay != "" and key_press_duration = "") {
+            SetKeyDelay(key_delay)
+        } else if (key_delay = "" and key_press_duration != "") {
+            SetKeyDelay(current_delay, key_press_duration)
+        }
     }
 
     Send("{Raw}" str)
@@ -2088,7 +2100,13 @@ AHKSendInput(args*) {
     current_key_duration := Format("{}", A_KeyDuration)
 
     if (key_delay != "" or key_press_duration != "") {
-        SetKeyDelay(key_delay, key_press_duration)
+        if (key_delay != "" and key_press_duration != "") {
+            SetKeyDelay(key_delay, key_press_duration)
+        } else if (key_delay != "" and key_press_duration = "") {
+            SetKeyDelay(key_delay)
+        } else if (key_delay = "" and key_press_duration != "") {
+            SetKeyDelay(current_delay, key_press_duration)
+        }
     }
 
     SendInput(str)
@@ -2109,7 +2127,13 @@ AHKSendEvent(args*) {
     current_key_duration := Format("{}", A_KeyDuration)
 
     if (key_delay != "" or key_press_duration != "") {
-        SetKeyDelay(key_delay, key_press_duration)
+        if (key_delay != "" and key_press_duration != "") {
+            SetKeyDelay(key_delay, key_press_duration)
+        } else if (key_delay != "" and key_press_duration = "") {
+            SetKeyDelay(key_delay)
+        } else if (key_delay = "" and key_press_duration != "") {
+            SetKeyDelay(current_delay, key_press_duration)
+        }
     }
 
     SendEvent(str)
@@ -2130,7 +2154,13 @@ AHKSendPlay(args*) {
     current_key_duration := Format("{}", A_KeyDurationPlay)
 
     if (key_delay != "" or key_press_duration != "") {
-        SetKeyDelay(key_delay, key_press_duration, "Play")
+        if (key_delay != "" and key_press_duration != "") {
+            SetKeyDelay(key_delay, key_press_duration)
+        } else if (key_delay != "" and key_press_duration = "") {
+            SetKeyDelay(key_delay)
+        } else if (key_delay = "" and key_press_duration != "") {
+            SetKeyDelay(current_delay, key_press_duration)
+        }
     }
 
     SendPlay(str)


### PR DESCRIPTION
This fixes a bug that occurs when using AHKv2 when using the `send` method (or other relevant methods like `send_input`, `send_play`, etc.) when only providing _either_ `key_delay` _or_ `key_press_duration`.

Resolves #315 