### PR TITLE
Ensure correct encoding for hotkeys scripts

### DIFF
--- a/ahk/_hotkey.py
+++ b/ahk/_hotkey.py
@@ -323,7 +323,9 @@ class ThreadedHotkeyTransport(HotkeyTransportBase):
     def listener(self) -> None:
         hotkey_script_contents = self._render_hotkey_template()
         logging.debug('hotkey script contents:\n%s', hotkey_script_contents)
-        with tempfile.NamedTemporaryFile(mode='w', prefix='python-ahk-hotkeys-', suffix='.ahk', delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            mode='w', prefix='python-ahk-hotkeys-', suffix='.ahk', delete=False, encoding='utf-8'
+        ) as f:
             f.write(hotkey_script_contents)
         atexit.register(try_remove, f.name)
         self._proc = subprocess.Popen(

--- a/tests/_async/test_keys.py
+++ b/tests/_async/test_keys.py
@@ -50,6 +50,17 @@ class TestKeysAsync(unittest.IsolatedAsyncioTestCase):
 
         assert 'by the way' in await self.win.get_text()
 
+    async def test_hotstring_cyrillic(self):
+        # https://github.com/spyoungtech/ahk/issues/328
+        self.ahk.add_hotstring('тест', 'hello world')
+        self.ahk.start_hotkeys()
+        await self.ahk.set_send_level(1)
+        await self.win.activate()
+        await self.ahk.send('тест ')
+        time.sleep(2)
+
+        assert 'hello world' in await self.win.get_text()
+
     async def test_remove_hotstring(self):
         self.ahk.add_hotstring('btw', 'by the way')
         self.ahk.start_hotkeys()

--- a/tests/_sync/test_keys.py
+++ b/tests/_sync/test_keys.py
@@ -49,6 +49,16 @@ class TestKeysAsync(unittest.TestCase):
 
         assert 'by the way' in self.win.get_text()
 
+    def test_hotstring_cyrillic(self):
+        self.ahk.add_hotstring('тест', 'hello world')
+        self.ahk.start_hotkeys()
+        self.ahk.set_send_level(1)
+        self.win.activate()
+        self.ahk.send('тест ')
+        time.sleep(2)
+
+        assert 'hello world' in self.win.get_text()
+
     def test_remove_hotstring(self):
         self.ahk.add_hotstring('btw', 'by the way')
         self.ahk.start_hotkeys()


### PR DESCRIPTION
Resolves GH-328

Hotkey scripts are generated using `tempfile.NamedTemporaryFile`, but this currently lacks a specified `encoding`, which results in the local encoding (i.e. `locale.getencoding()`) being used, which will likely produce problems.

When the hotstring characters are not valid in the local default encoding, the script generation can fail:

```py
ahk.add_hotstring('тест', 'hello world!')
ahk.start_hotkeys()
```

```py
Exception in thread Thread-3 (listener):
Traceback (most recent call last):
  File "C:\Python310\lib\threading.py", line 1009, in _bootstrap_inner
    self.run()
  File "C:\Python310\lib\threading.py", line 946, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\Spencer\repos\ahk\ahk\_hotkey.py", line 327, in listener
    f.write(hotkey_script_contents)
  File "C:\Python310\lib\tempfile.py", line 483, in func_wrapper
    return func(*args, **kwargs)
  File "C:\Python310\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 4095-4098: character maps to <undefined>
```

I suspect that, even if this somehow succeeds because the local encoding is valid (say, CP808 or CP866) , the resulting script will either fail to start or not work as expected because it is explicitly started with the `/CP65001` flag, which is likely a mismatch against the local encoding used to write the file.

This problem only affects hotstrings that either use characters that are invalid in the local encoding or when the hotstring characters encoded in the local encoding do not overlap correctly with UTF-8.

It may be possible to register hotstrings similar to how we register hotkeys to make hotstrings more resilient to these kinds of problems, but this change should be made in any case.