### PR TITLE
GH-338 allow garbage collection of non-daemon processes

### DIFF
--- a/buildunasync.py
+++ b/buildunasync.py
@@ -19,6 +19,7 @@ build_py = unasync.cmdclass_build_py(
                 'AsyncFutureResult': 'FutureResult',
                 '_async_run_nonblocking': '_sync_run_nonblocking',
                 'acommunicate': 'communicate',
+                'astart': 'start',
                 # "__aenter__": "__aenter__",
             },
         ),


### PR DESCRIPTION
As described in #338 use of `atexit.register` in `AsyncAHKProcess` causes a reference to be held for the subprocess. In use cases that make heavy use of `run_script` or calls with `blocking=False`, this can lead to buildup of memory. The rate of growth can be dependent on the size of the value returned by the script and how often it is called.

This PR fixes this issue by avoiding the need for `atexit.register` for these two scenarios. `atexit.register` is still used for the long-running daemon process to ensure cleanup.