### PR TITLE
Improve version specific executable searching.

### DIFF
--- a/ahk/_utils.py
+++ b/ahk/_utils.py
@@ -103,14 +103,15 @@ def _resolve_executable_path(executable_path: str = '', version: Optional[Litera
 
     if not executable_path and version:
         if os.path.exists(DEFAULT_INSTALL_PATH):
-            for exe in EXECUTABLES:
-                path = os.path.join(DEFAULT_INSTALL_PATH, exe)
-                if os.path.exists(path):
-                    executable_path = path
-                    break
-
+            if version == 'v1':
+                for exe in EXECUTABLES:
+                    path = os.path.join(DEFAULT_INSTALL_PATH, exe)
+                    if os.path.exists(path):
+                        executable_path = path
+                        break
+            
             if not executable_path:
-                for direc in os.listdir(DEFAULT_INSTALL_PATH):               
+                for direc in os.listdir(DEFAULT_INSTALL_PATH):           
                     if not os.path.isdir(os.path.join(DEFAULT_INSTALL_PATH, direc)) or not direc.startswith(version):
                         continue
 

--- a/ahk/_utils.py
+++ b/ahk/_utils.py
@@ -83,8 +83,8 @@ class MsgBoxOtherOptions(enum.IntEnum):
     RIGHT_TO_LEFT_READING_ORDER = 1048576
 
 
-DEFAULT_EXECUTABLE_PATH = r'C:\Program Files\AutoHotkey\AutoHotkey.exe'
-DEFAULT_EXECUTABLE_PATH_V2 = r'C:\Program Files\AutoHotkey\v2\AutoHotkey64.exe'
+DEFAULT_INSTALL_PATH = r'C:\Program Files\AutoHotkey'
+EXECUTABLES = ['AutoHotkey.exe', 'AutoHotkey64.exe', 'AutoHotkey32.exe', 'AutoHotkeyU64.exe', 'AutoHotkeyU32.exe', 'AutoHotkeyA32.exe']
 
 
 def _resolve_executable_path(executable_path: str = '', version: Optional[Literal['v1', 'v2']] = None) -> str:
@@ -101,13 +101,28 @@ def _resolve_executable_path(executable_path: str = '', version: Optional[Litera
             or ''
         )
 
-    if not executable_path:
-        if version == 'v2':
-            if os.path.exists(DEFAULT_EXECUTABLE_PATH_V2):
-                executable_path = DEFAULT_EXECUTABLE_PATH_V2
-        else:
-            if os.path.exists(DEFAULT_EXECUTABLE_PATH):
-                executable_path = DEFAULT_EXECUTABLE_PATH
+    if not executable_path and version:
+        if os.path.exists(DEFAULT_INSTALL_PATH):
+            for exe in EXECUTABLES:
+                path = os.path.join(DEFAULT_INSTALL_PATH, exe)
+                if os.path.exists(path):
+                    executable_path = path
+                    break
+
+            if not executable_path:
+                for direc in os.listdir(DEFAULT_INSTALL_PATH):               
+                    if not os.path.isdir(os.path.join(DEFAULT_INSTALL_PATH, direc)) or not direc.startswith(version):
+                        continue
+
+                    dir_path = os.path.join(DEFAULT_INSTALL_PATH, direc)
+                    for exe in EXECUTABLES:
+                        path = os.path.join(dir_path, exe)
+                        if os.path.exists(path):
+                            executable_path = path
+                            break
+                    
+                    if executable_path:
+                        break
 
     if not executable_path:
         raise AhkExecutableNotFoundError(


### PR DESCRIPTION
I was having some issues testing v1 behavior while working on another pull request because the library couldn't find my v1 installation. I completely uninstalled AutoHotkey twice and tested two install configurations to see how it behaved and rewrote the executable searching code to accommodate it.

The first time I installed v1 then v2. In this case, v1 installed into `C:\Program Files\AutoHotkey` and v2 installed into `C:\Program Files\AutoHotkey\v2`.

The second time I installed v2 then v1 (how I originally had it installed). In this case, v2 installed into `C:\Program Files\AutoHotkey\v2` and v1 installed into `C:\Program Files\AutoHotkey\v1.1.37.02`.

So the rewritten code will search the top level install directory if v1 is selected, otherwise it will search for `v1...` or `v2...` directories and then search there. 

I put all of the executables in a single list to save a line and an if statement but can split it if necessary.

```py
EXECUTABLES = ['AutoHotkey.exe', 'AutoHotkey64.exe', 'AutoHotkey32.exe', 'AutoHotkeyU64.exe', 'AutoHotkeyU32.exe', 'AutoHotkeyA32.exe']
# vs
V2_EXECUTABLES = ['AutoHotkey.exe', 'AutoHotkey64.exe', 'AutoHotkey32.exe']
V1_EXECUTABLES = ['AutoHotkey.exe', 'AutoHotkeyU64.exe', 'AutoHotkeyU32.exe', 'AutoHotkeyA32.exe']
```