### PR TITLE
gh-361 fix bug in show_tooltip that silently omitted `which` argument

### DIFF
--- a/ahk/_async/engine.py
+++ b/ahk/_async/engine.py
@@ -1605,6 +1605,7 @@ class AsyncAHK(Generic[T_AHKVersion]):
             args.append(str(y))
         else:
             args.append('')
+        args.append(str(which))
         await self._transport.function_call('AHKShowToolTip', args)
 
     async def hide_tooltip(self, which: int = 1) -> None:

--- a/ahk/_sync/engine.py
+++ b/ahk/_sync/engine.py
@@ -1592,6 +1592,7 @@ class AHK(Generic[T_AHKVersion]):
             args.append(str(y))
         else:
             args.append('')
+        args.append(str(which))
         self._transport.function_call('AHKShowToolTip', args)
 
     def hide_tooltip(self, which: int = 1) -> None:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ unasync
 black
 tokenize-rt
 coverage
-mypy
+mypy==1.13.0
 typing_extensions
 jinja2
 pytest-rerunfailures


### PR DESCRIPTION
Fixes a problem where the `which` argument in `show_tooltip` was not passed to AHK. This means this argument was effectively ignored in AHK v1 and causes an error in AHK v2. This PR fixes the oversight.

Resolves #361 