### PR TITLE
fix show_tooltip for AHK v2

### DIFF
--- a/ahk/_async/transport.py
+++ b/ahk/_async/transport.py
@@ -321,8 +321,7 @@ class AsyncTransport(ABC):
     @abstractmethod
     async def run_script(
         self, script_text_or_path: str, /, *, blocking: bool = True, timeout: Optional[int] = None
-    ) -> Union[str, AsyncFutureResult[str]]:
-        return NotImplemented
+    ) -> Union[str, AsyncFutureResult[str]]: ...
 
     # fmt: off
     @overload
@@ -565,22 +564,21 @@ class AsyncTransport(ABC):
     @abstractmethod
     async def send(
         self, request: RequestMessage, engine: Optional[AsyncAHK[Any]] = None
-    ) -> Union[None, Tuple[int, int], int, str, bool, AsyncWindow, List[AsyncWindow], List[AsyncControl]]:
-        return NotImplemented
+    ) -> Union[None, Tuple[int, int], int, str, bool, AsyncWindow, List[AsyncWindow], List[AsyncControl]]: ...
 
     @abstractmethod  # unasync: remove
     async def a_send_nonblocking(  # unasync: remove
         self, request: RequestMessage, engine: Optional[AsyncAHK[Any]] = None
     ) -> AsyncFutureResult[
         Union[None, Tuple[int, int], int, str, bool, AsyncWindow, List[AsyncWindow], List[AsyncControl]]
-    ]:
-        return NotImplemented
+    ]: ...
 
     @abstractmethod
     def send_nonblocking(
         self, request: RequestMessage, engine: Optional[AsyncAHK[Any]] = None
-    ) -> FutureResult[Union[None, Tuple[int, int], int, str, bool, AsyncWindow, List[AsyncWindow], List[AsyncControl]]]:
-        return NotImplemented
+    ) -> FutureResult[
+        Union[None, Tuple[int, int], int, str, bool, AsyncWindow, List[AsyncWindow], List[AsyncControl]]
+    ]: ...
 
 
 class AsyncDaemonProcessTransport(AsyncTransport):

--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -5704,7 +5704,13 @@ AHKShowToolTip(args*) {
     x := args[2]
     y := args[3]
     which := args[4]
-    ToolTip(text, x, y, which)
+
+    ToolTip(text, IsNumber(x) ? Number(x) : unset, IsNumber(y) ? Number(y) : unset, which || unset)
+    ; In AHK v2, doubling the call to ToolTip seems necessary to ensure synchronous creation of the window
+    ; This seems to be more reliable than sleeping to wait for the tooltip callback
+    ; Without this doubled up call (or a sleep) we return the the blocking loop (awaiting next command from Python)
+    ;  before the tooltip window is created, meaning the tooltip will not show until if/when processing the next command
+    ToolTip(text, IsNumber(x) ? Number(x) : unset, IsNumber(y) ? Number(y) : unset, which || unset)
     return FormatNoValueResponse()
     {% endblock AHKShowToolTip %}
 }

--- a/ahk/_sync/transport.py
+++ b/ahk/_sync/transport.py
@@ -293,7 +293,7 @@ class Transport(ABC):
     def run_script(
         self, script_text_or_path: str, /, *, blocking: bool = True, timeout: Optional[int] = None
     ) -> Union[str, FutureResult[str]]:
-        return NotImplemented
+        ...
 
     # fmt: off
     @overload
@@ -537,14 +537,14 @@ class Transport(ABC):
     def send(
         self, request: RequestMessage, engine: Optional[AHK[Any]] = None
     ) -> Union[None, Tuple[int, int], int, str, bool, Window, List[Window], List[Control]]:
-        return NotImplemented
+        ...
 
 
     @abstractmethod
     def send_nonblocking(
         self, request: RequestMessage, engine: Optional[AHK[Any]] = None
     ) -> FutureResult[Union[None, Tuple[int, int], int, str, bool, Window, List[Window], List[Control]]]:
-        return NotImplemented
+        ...
 
 
 class DaemonProcessTransport(Transport):

--- a/ahk/templates/daemon-v2.ahk
+++ b/ahk/templates/daemon-v2.ahk
@@ -2691,7 +2691,13 @@ AHKShowToolTip(args*) {
     x := args[2]
     y := args[3]
     which := args[4]
-    ToolTip(text, x, y, which)
+
+    ToolTip(text, IsNumber(x) ? Number(x) : unset, IsNumber(y) ? Number(y) : unset, which || unset)
+    ; In AHK v2, doubling the call to ToolTip seems necessary to ensure synchronous creation of the window
+    ; This seems to be more reliable than sleeping to wait for the tooltip callback
+    ; Without this doubled up call (or a sleep) we return the the blocking loop (awaiting next command from Python)
+    ;  before the tooltip window is created, meaning the tooltip will not show until if/when processing the next command
+    ToolTip(text, IsNumber(x) ? Number(x) : unset, IsNumber(y) ? Number(y) : unset, which || unset)
     return FormatNoValueResponse()
     {% endblock AHKShowToolTip %}
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ unasync
 black
 tokenize-rt
 coverage
-mypy==1.13.0
+mypy
 typing_extensions
 jinja2
 pytest-rerunfailures


### PR DESCRIPTION
ensures that arguments are correctly parsed as numbers when provided and fixes a problem in AHKv2 where the tooltip window creation may be blocked by returning to the blocking daemon input loop until the next command invocation

Previously, an error may be thrown when `x` or `y` parameters were not provided when using AHK v2 and tooltips for successful calls may be delayed until a subsequent command is received.

Completes the fix from #362 and fully resolves #361

This also reverts a change that pinned `mypy` to 1.13.0 to avoid new typing issues that arose with abstract methods when upgrading `mypy` to 1.14.1 -- the typing issues were resolved and mypy has been unpinned.