### PR TITLE
add coord_mode keyword arg for mouse_move

### DIFF
--- a/ahk/_async/engine.py
+++ b/ahk/_async/engine.py
@@ -750,13 +750,13 @@ class AsyncAHK(Generic[T_AHKVersion]):
 
     # fmt: off
     @overload
-    async def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, speed: Optional[int] = None, relative: bool = False, send_mode: Optional[SendMode] = None) -> None: ...
+    async def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, speed: Optional[int] = None, relative: bool = False, send_mode: Optional[SendMode] = None, coord_mode: Optional[CoordModeRelativeTo] = None) -> None: ...
     @overload
-    async def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, blocking: Literal[True], speed: Optional[int] = None, relative: bool = False, send_mode: Optional[SendMode] = None) -> None: ...
+    async def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, blocking: Literal[True], speed: Optional[int] = None, relative: bool = False, send_mode: Optional[SendMode] = None, coord_mode: Optional[CoordModeRelativeTo] = None) -> None: ...
     @overload
-    async def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, blocking: Literal[False], speed: Optional[int] = None, relative: bool = False, send_mode: Optional[SendMode] = None) -> AsyncFutureResult[None]: ...
+    async def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, blocking: Literal[False], speed: Optional[int] = None, relative: bool = False, send_mode: Optional[SendMode] = None, coord_mode: Optional[CoordModeRelativeTo] = None) -> AsyncFutureResult[None]: ...
     @overload
-    async def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, speed: Optional[int] = None, relative: bool = False, blocking: bool = True, send_mode: Optional[SendMode] = None) -> Union[None, AsyncFutureResult[None]]: ...
+    async def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, speed: Optional[int] = None, relative: bool = False, blocking: bool = True, send_mode: Optional[SendMode] = None, coord_mode: Optional[CoordModeRelativeTo] = None) -> Union[None, AsyncFutureResult[None]]: ...
     # fmt: on
     async def mouse_move(
         self,
@@ -767,6 +767,7 @@ class AsyncAHK(Generic[T_AHKVersion]):
         relative: bool = False,
         send_mode: Optional[SendMode] = None,
         blocking: bool = True,
+        coord_mode: Optional[CoordModeRelativeTo] = None,
     ) -> Union[None, AsyncFutureResult[None]]:
         """
         Analog for `MouseMove <https://www.autohotkey.com/docs/commands/MouseMove.htm>`_
@@ -788,6 +789,11 @@ class AsyncAHK(Generic[T_AHKVersion]):
             args.append('')
         if send_mode:
             args.append(send_mode)
+        else:
+            args.append('')
+
+        if coord_mode:
+            args.append(coord_mode)
         else:
             args.append('')
 

--- a/ahk/_constants.py
+++ b/ahk/_constants.py
@@ -1707,11 +1707,34 @@ AHKMouseMove(args*) {
     y := args[2]
     speed := args[3]
     relative := args[4]
+    send_mode := args[5]
+    coord_mode := args[6]
+
+    current_send_mode := Format("{}", A_SendMode)
+    current_coord_mode := Format("{}", A_CoordModeMouse)
+
+    if (send_mode != "") {
+        SendMode, %send_mode%
+    }
+
+    if (coord_mode != "") {
+        CoordMode, Mouse, %coord_mode%
+    }
+
     if (relative != "") {
     MouseMove, %x%, %y%, %speed%, R
     } else {
     MouseMove, %x%, %y%, %speed%
     }
+
+    if (send_mode != "") {
+        SendMode, %current_send_mode%
+    }
+
+    if (coord_mode != "") {
+        CoordMode, Mouse, %current_coord_mode%
+    }
+
     resp := FormatNoValueResponse()
     return resp
     {% endblock AHKMouseMove %}
@@ -4820,7 +4843,15 @@ AHKMouseMove(args*) {
     speed := args[3]
     relative := args[4]
     send_mode := args[5]
+    coord_mode := args[6]
     current_send_mode := Format("{}", A_SendMode)
+
+    current_coord_mode := Format("{}", A_CoordModeMouse)
+    if (coord_mode != "") {
+        CoordMode("Mouse", coord_mode)
+    }
+
+
 
     if (send_mode != "") {
         SendMode send_mode
@@ -4834,6 +4865,10 @@ AHKMouseMove(args*) {
 
     if (send_mode != "") {
         SendMode current_send_mode
+    }
+
+    if (coord_mode != "") {
+        CoordMode("Mouse", current_coord_mode)
     }
 
     resp := FormatNoValueResponse()

--- a/ahk/_sync/engine.py
+++ b/ahk/_sync/engine.py
@@ -740,13 +740,13 @@ class AHK(Generic[T_AHKVersion]):
 
     # fmt: off
     @overload
-    def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, speed: Optional[int] = None, relative: bool = False, send_mode: Optional[SendMode] = None) -> None: ...
+    def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, speed: Optional[int] = None, relative: bool = False, send_mode: Optional[SendMode] = None, coord_mode: Optional[CoordModeRelativeTo] = None) -> None: ...
     @overload
-    def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, blocking: Literal[True], speed: Optional[int] = None, relative: bool = False, send_mode: Optional[SendMode] = None) -> None: ...
+    def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, blocking: Literal[True], speed: Optional[int] = None, relative: bool = False, send_mode: Optional[SendMode] = None, coord_mode: Optional[CoordModeRelativeTo] = None) -> None: ...
     @overload
-    def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, blocking: Literal[False], speed: Optional[int] = None, relative: bool = False, send_mode: Optional[SendMode] = None) -> FutureResult[None]: ...
+    def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, blocking: Literal[False], speed: Optional[int] = None, relative: bool = False, send_mode: Optional[SendMode] = None, coord_mode: Optional[CoordModeRelativeTo] = None) -> FutureResult[None]: ...
     @overload
-    def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, speed: Optional[int] = None, relative: bool = False, blocking: bool = True, send_mode: Optional[SendMode] = None) -> Union[None, FutureResult[None]]: ...
+    def mouse_move(self, x: Optional[Union[str, int]] = None, y: Optional[Union[str, int]] = None, *, speed: Optional[int] = None, relative: bool = False, blocking: bool = True, send_mode: Optional[SendMode] = None, coord_mode: Optional[CoordModeRelativeTo] = None) -> Union[None, FutureResult[None]]: ...
     # fmt: on
     def mouse_move(
         self,
@@ -757,6 +757,7 @@ class AHK(Generic[T_AHKVersion]):
         relative: bool = False,
         send_mode: Optional[SendMode] = None,
         blocking: bool = True,
+        coord_mode: Optional[CoordModeRelativeTo] = None,
     ) -> Union[None, FutureResult[None]]:
         """
         Analog for `MouseMove <https://www.autohotkey.com/docs/commands/MouseMove.htm>`_
@@ -778,6 +779,11 @@ class AHK(Generic[T_AHKVersion]):
             args.append('')
         if send_mode:
             args.append(send_mode)
+        else:
+            args.append('')
+
+        if coord_mode:
+            args.append(coord_mode)
         else:
             args.append('')
 

--- a/ahk/templates/daemon-v2.ahk
+++ b/ahk/templates/daemon-v2.ahk
@@ -1807,7 +1807,15 @@ AHKMouseMove(args*) {
     speed := args[3]
     relative := args[4]
     send_mode := args[5]
+    coord_mode := args[6]
     current_send_mode := Format("{}", A_SendMode)
+
+    current_coord_mode := Format("{}", A_CoordModeMouse)
+    if (coord_mode != "") {
+        CoordMode("Mouse", coord_mode)
+    }
+
+
 
     if (send_mode != "") {
         SendMode send_mode
@@ -1821,6 +1829,10 @@ AHKMouseMove(args*) {
 
     if (send_mode != "") {
         SendMode current_send_mode
+    }
+
+    if (coord_mode != "") {
+        CoordMode("Mouse", current_coord_mode)
     }
 
     resp := FormatNoValueResponse()

--- a/ahk/templates/daemon.ahk
+++ b/ahk/templates/daemon.ahk
@@ -1704,11 +1704,34 @@ AHKMouseMove(args*) {
     y := args[2]
     speed := args[3]
     relative := args[4]
+    send_mode := args[5]
+    coord_mode := args[6]
+
+    current_send_mode := Format("{}", A_SendMode)
+    current_coord_mode := Format("{}", A_CoordModeMouse)
+
+    if (send_mode != "") {
+        SendMode, %send_mode%
+    }
+
+    if (coord_mode != "") {
+        CoordMode, Mouse, %coord_mode%
+    }
+
     if (relative != "") {
     MouseMove, %x%, %y%, %speed%, R
     } else {
     MouseMove, %x%, %y%, %speed%
     }
+
+    if (send_mode != "") {
+        SendMode, %current_send_mode%
+    }
+
+    if (coord_mode != "") {
+        CoordMode, Mouse, %current_coord_mode%
+    }
+
     resp := FormatNoValueResponse()
     return resp
     {% endblock AHKMouseMove %}


### PR DESCRIPTION
Adds `coord_mode` keyword argument to `mouse_move` allowing the coordinate mode to be changed for individual function invocations (rather than requiring a persistent global state change via `set_coord_mode`)

Additionally, this change also fixes a bug that occurs when using AHK v1 where the `send_mode` keyword argument was being ignored. Now the `send_mode` argument is respected as it is when using AHK v2.